### PR TITLE
chore: add pr linting for conventional commit style

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,78 @@
+---
+name: "pr lint"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  prlint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            chore
+            ci
+            docs
+            feat
+            fix
+            refactor
+            revert
+            style
+            test
+          # Configure which scopes are allowed.
+          scopes: |
+            roleassignment
+            root
+            subscription
+            virtualnetwork
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles. For instance by setting
+          # the value below, `chore(release): ...` and `ci(e2e,release): ...` will be rejected.
+          disallowScopes: |
+            release
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # If you use GitHub Enterprise, you can set this to the URL of your server
+          githubBaseUrl: https://github.myorg.com/api/v3
+          # If the PR contains one of these labels, the validation is skipped.
+          # Multiple labels can be separated by newlines.
+          # If you want to rerun the validation when labels change, you might want
+          # to use the `labeled` and `unlabeled` event triggers in your workflow.
+          ignoreLabels: |
+            bot
+          # If you're using a format for the PR title that differs from the traditional Conventional
+          # Commits spec, you can use these options to customize the parsing of the type, scope and
+          # subject. The `headerPattern` should contain a regex where the capturing groups in parentheses
+          # correspond to the parts listed in `headerPatternCorrespondence`.
+          # See: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#headerpattern
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPatternCorrespondence: type, scope, subject
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: false

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -79,3 +79,44 @@ The following environment variables are required for deployment testing:
 * `AZURE_SUBSCRIPTION_ID` - set to the subscription id to use for deployment testing.
 * `AZURE_TENANT_ID` - set to the tenant id of the Azure account.
 * `TERRATEST_DEPLOY` - set to a non-empty value to run the deployemnt tests. `make testdeploy` will do this for you.
+
+## PR Naming
+
+We have adopted [conventional commit](https://www.conventionalcommits.org/) naming standards for PRs.
+
+E.g.:
+
+```text
+feat(roleassignment)!: Add `relative_scope` value.
+^    ^              ^ ^
+|    |              | |__ Subject
+|    |_____ Scope   |____ Breaking change flag
+|__________ Type
+```
+
+### Type
+
+The following types are permitted:
+
+* `chore` - Other changes that do not modify src or test files
+* `ci` - changes to the CI system
+* `docs` - documentation only changes
+* `feat` - a new feature (this correlates with `MINOR` in Semantic Versioning)
+* `fix` - a bug fix (this correlates with `PATCH` in Semantic Versioning)
+* `refactor` - a code change that neither fixes a bug or adds a feature
+* `revert` - revert to a previous commit
+* `style` - changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* `test` - adding or correcting tests
+
+### Scope (Optional)
+
+The following scopes are permitted:
+
+* roleassignment - pertaining to the roleassignment sub-module
+* root - pertaining to the root module
+* subscription - pertaining to the subscription sub-module
+* virtualnetwork - pertaining to the virtual network sub-module
+
+### Breaking Changes
+
+An exclamation mark `!` is appended to the type/scope of a breaking change PR (this correlates with `MAJOR` in Semantic Versioning).


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run `make docs` and `make fmt` to update the documentation and format your code.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] (Optionally) Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
