### PR TITLE
docs: correct releases link in README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Please provide testing evidence to show that your Pull Request works/fixes as de
 
 - [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
 - [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
-- [ ] Run `make docs` and `make fmt` to update the documentation and format your code.
+- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
 - [ ] Created unit and deployment tests and provided evidence.
 - [ ] Updated relevant and associated documentation.
 - [ ] (Optionally) Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please raise an [issue](https://github.com/Azure/terraform-azurerm-lz-vending/is
 
 ## Change log
 
-Please see the [GitHub releases pages](https://github.com/Azure/terraform-azurerm-lz-vending/releases/latest) for change log information.
+Please see the [GitHub releases pages](https://github.com/Azure/terraform-azurerm-lz-vending/releases) for change log information.
 
 ## Notes
 

--- a/header.md
+++ b/header.md
@@ -18,7 +18,7 @@ Please raise an [issue](https://github.com/Azure/terraform-azurerm-lz-vending/is
 
 ## Change log
 
-Please see the [GitHub releases pages](https://github.com/Azure/terraform-azurerm-lz-vending/releases/latest) for change log information.
+Please see the [GitHub releases pages](https://github.com/Azure/terraform-azurerm-lz-vending/releases) for change log information.
 
 ## Notes
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

Corrects releases link in readme.md

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run `make docs` and `make fmt` to update the documentation and format your code.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] (Optionally) Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
