### PR TITLE
ci: do not require pr title lint for dependencies

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -24,23 +24,14 @@ jobs:
           # Default: https://github.com/commitizen/conventional-commit-types
           types: |
             chore
-            chore!
             ci
-            ci!
             docs
-            docs!
             feat
-            feat!
             fix
-            fix!
             refactor
-            refactor!
             revert
-            revert!
             style
-            style!
             test
-            test!
           # Configure which scopes are allowed.
           scopes: |
             roleassignment
@@ -70,13 +61,13 @@ jobs:
           # If you want to rerun the validation when labels change, you might want
           # to use the `labeled` and `unlabeled` event triggers in your workflow.
           ignoreLabels: |
-            bot
+            dependencies
           # If you're using a format for the PR title that differs from the traditional Conventional
           # Commits spec, you can use these options to customize the parsing of the type, scope and
           # subject. The `headerPattern` should contain a regex where the capturing groups in parentheses
           # correspond to the parts listed in `headerPatternCorrespondence`.
           # See: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#headerpattern
-          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPattern: '^(\w*)!?(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
           headerPatternCorrespondence: type, scope, subject
           # For work-in-progress PRs you can typically use draft pull requests
           # from GitHub. However, private repositories on the free plan don't have


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. As title
2. Refined title regex to allow optional '!' to indicate breaking change




## Testing Evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [x] Created unit and deployment tests and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] (Optionally) Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
