### PR TITLE
fix: allow ResourceGroups names to have specific special characters

### DIFF
--- a/modules/virtualnetwork/variables.tf
+++ b/modules/virtualnetwork/variables.tf
@@ -191,7 +191,7 @@ DESCRIPTION
   validation {
     condition = alltrue([
       for k, v in var.virtual_networks :
-      can(regex("^$|^/subscriptions/[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}/resourceGroups/[\\w]{1,89}[^\\s.]/providers/Microsoft.Network/virtualHubs/[\\w-_.]{1,80}/hubRouteTables/[\\w-_.]{1,80}$", v.vwan_associated_routetable_resource_id)) if v.vwan_connection_enabled
+      can(regex("^$|^/subscriptions/[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}/resourceGroups/[\\w-._]{1,89}[^\\s.]/providers/Microsoft.Network/virtualHubs/[\\w-_.]{1,80}/hubRouteTables/[\\w-_.]{1,80}$", v.vwan_associated_routetable_resource_id)) if v.vwan_connection_enabled
     ])
     error_message = "The vWAN associated routetable resource id must be an Azure vwan hub routetable resource id, e.g. /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualHubs/my-vhub/hubRouteTables/defaultRouteTable."
   }
@@ -202,7 +202,7 @@ DESCRIPTION
       for k, v in var.virtual_networks :
       [
         for i in v.vwan_propagated_routetables_resource_ids :
-        can(regex("^$|^/subscriptions/[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}/resourceGroups/[\\w]{1,89}[^\\s.]/providers/Microsoft.Network/virtualHubs/[\\w-_.]{1,80}/hubRouteTables/[\\w-_.]{1,80}$", i))
+        can(regex("^$|^/subscriptions/[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}/resourceGroups/[\\w-._]{1,89}[^\\s.]/providers/Microsoft.Network/virtualHubs/[\\w-_.]{1,80}/hubRouteTables/[\\w-_.]{1,80}$", i))
       ] if v.vwan_connection_enabled
     ]))
     error_message = "The vWAN propagated routetables resource id must be an Azure vwan hub routetable resource id, e.g. /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualHubs/my-vhub/hubRouteTables/defaultRouteTable."


### PR DESCRIPTION
# Overview/summary

routetables should be allowed in ResourceGroups with specific special characters (like '-' and '.')
allow: "my-rg-test" and "my.rg.test"
disallow: "my-rg-test " or "my-rg-test."

Changed ```resourceGroups/[\\w]``` to ```resourceGroups/[\\w-._]``` to allow the special characters '-' and '.', like in the other validation checks.


## This PR fixes/adds/changes/removes

Allows users to have ResourceGroups named like "my-rg-test" and create routetable in it.


## Testing evidence

Not needed, because other validation checks have this already included.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
