### PR TITLE
ci: add labeled event trigger for pr

### DIFF
--- a/.github/workflows/go-test-unit.yml
+++ b/.github/workflows/go-test-unit.yml
@@ -3,7 +3,7 @@ name: Unit test
 
 on:
   pull_request_target:
-    types: ['opened', 'reopened', 'synchronize']
+    types: ['opened', 'reopened', 'synchronize', 'labeled']
   workflow_dispatch:
     inputs:
       test_filter:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Add 'labeled' to PR trigger to make it work with 3rd party PRs
