### PR TITLE
feat: create an output for management_group_subscription_association_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Default: `""`
 
 ### <a name="input_subscription_management_group_association_enabled"></a> [subscription\_management\_group\_association\_enabled](#input\_subscription\_management\_group\_association\_enabled)
 
-Description: Whether to create the `azurerm_management_group_association` resource.
+Description: Whether to create the `azurerm_management_group_subscription_association` resource.
 
 If enabled, the `subscription_management_group_id` must also be supplied.
 
@@ -523,6 +523,11 @@ The following resources are used by this module:
 ## Outputs
 
 The following outputs are exported:
+
+### <a name="output_management_group_subscription_association_id"></a> [management\_group\_subscription\_association\_id](#output\_management\_group\_subscription\_association\_id)
+
+Description: The management\_group\_subscription\_association\_id output is the ID of the management group subscription association.  
+Value will be null if `var.subscription_management_group_association_enabled` is false.
 
 ### <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id)
 

--- a/modules/subscription/README.md
+++ b/modules/subscription/README.md
@@ -131,7 +131,7 @@ Default: `""`
 
 ### <a name="input_subscription_management_group_association_enabled"></a> [subscription\_management\_group\_association\_enabled](#input\_subscription\_management\_group\_association\_enabled)
 
-Description: Whether to create the `azurerm_management_group_association` resource.
+Description: Whether to create the `azurerm_management_group_subscription_association` resource.
 
 If enabled, the `subscription_management_group_id` must also be supplied.
 
@@ -192,6 +192,11 @@ The following resources are used by this module:
 ## Outputs
 
 The following outputs are exported:
+
+### <a name="output_management_group_subscription_association_id"></a> [management\_group\_subscription\_association\_id](#output\_management\_group\_subscription\_association\_id)
+
+Description: The management\_group\_subscription\_association\_id output is the ID of the management group subscription association.  
+Value will be null if `var.subscription_management_group_association_enabled` is false.
 
 ### <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id)
 

--- a/modules/subscription/outputs.tf
+++ b/modules/subscription/outputs.tf
@@ -13,3 +13,11 @@ The subscription_resource_id output is the Azure resource id for the newly creat
 Value will be null if `var.subscription_id` is blank and `var.subscription_alias_enabled` is false.
 DESCRIPTION
 }
+
+output "management_group_subscription_association_id" {
+  value       = var.subscription_management_group_association_enabled ? azurerm_management_group_subscription_association.this[0].id : null
+  description = <<DESCRIPTION
+The management_group_subscription_association_id output is the ID of the management group subscription association.
+Value will be null if `var.subscription_management_group_association_enabled` is false.
+DESCRIPTION
+}

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -121,7 +121,7 @@ variable "subscription_management_group_association_enabled" {
   type        = bool
   default     = false
   description = <<DESCRIPTION
-Whether to create the `azurerm_management_group_association` resource.
+Whether to create the `azurerm_management_group_subscription_association` resource.
 
 If enabled, the `subscription_management_group_id` must also be supplied.
 DESCRIPTION

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,11 @@ output "virtual_network_resource_ids" {
   value       = local.virtual_network_resource_ids
   description = "A map of virtual network resource ids, keyed by the var.virtual_networks input map. Only populated if the virtualnetwork submodule is enabled."
 }
+
+output "management_group_subscription_association_id" {
+  value       = var.subscription_management_group_association_enabled ? module.subscription[0].management_group_subscription_association_id : null
+  description = <<DESCRIPTION
+The management_group_subscription_association_id output is the ID of the management group subscription association.
+Value will be null if `var.subscription_management_group_association_enabled` is false.
+DESCRIPTION
+}

--- a/variables.subscription.tf
+++ b/variables.subscription.tf
@@ -100,7 +100,7 @@ variable "subscription_management_group_association_enabled" {
   type        = bool
   default     = false
   description = <<DESCRIPTION
-Whether to create the `azurerm_management_group_association` resource.
+Whether to create the `azurerm_management_group_subscription_association` resource.
 
 If enabled, the `subscription_management_group_id` must also be supplied.
 DESCRIPTION


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

This PR creates an output `management_group_subscription_association_id`, which outputs the ID of the Management Group Subscription association **if** `var.subscription_management_group_association_enabled` was set to true, otherwise the value of the output will be `null`.

## This PR fixes/adds/changes/removes

The reason for this change is that we are creating custom Role Definitions at the Management Group scope, and are unable to perform Role Assignments until the Subscription is assigned to a Management Group. Rather than depending on the entire subscription module call to be complete, this output allows us to set a dependency on only the management group association resource.


### Breaking changes

None

## Testing evidence

I've tested with my fork of the module and it behaves as expected, generating the association id output.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure. (none related)
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [x] Updated relevant and associated documentation.