### PR TITLE
feat: routing Intent vhub connection configuration

### DIFF
--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,8 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      routingConfiguration = each.value.vwan_routing_intent_enabled ?
+      each.value.vwan_routing_intent_enabled ? routingConfiguration = {} :
+      routingConfiguration =
         {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
@@ -176,7 +177,7 @@ resource "azapi_resource" "vhubconnection" {
             ids    = each.value.vwan_security_configuration.secure_private_traffic ? local.vwan_propagated_noneroutetables_resource_ids[each.key] : local.vwan_propagated_routetables_resource_ids[each.key]
             labels = each.value.vwan_security_configuration.secure_private_traffic ? ["none"] : local.vwan_propagated_routetables_labels[each.key]
           }
-        } : {}
+        }
     }
   })
 }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,8 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      each.value.vwan_routing_intent_enabled ? "routingConfiguration = {}" : "routingConfiguration =
-        {
+      routingConfiguration = each.value.vwan_routing_intent_enabled ? {} : {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
           }
@@ -176,7 +175,7 @@ resource "azapi_resource" "vhubconnection" {
             ids    = each.value.vwan_security_configuration.secure_private_traffic ? local.vwan_propagated_noneroutetables_resource_ids[each.key] : local.vwan_propagated_routetables_resource_ids[each.key]
             labels = each.value.vwan_security_configuration.secure_private_traffic ? ["none"] : local.vwan_propagated_routetables_labels[each.key]
           }
-        }"
+        }
     }
   })
 }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      routingConfiguration = merge(
+      routingConfiguration = each.value.vwan_routing_intent_enabled ? merge(
         {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
@@ -176,15 +176,7 @@ resource "azapi_resource" "vhubconnection" {
             ids    = each.value.vwan_security_configuration.secure_private_traffic ? local.vwan_propagated_noneroutetables_resource_ids[each.key] : local.vwan_propagated_routetables_resource_ids[each.key]
             labels = each.value.vwan_security_configuration.secure_private_traffic ? ["none"] : local.vwan_propagated_routetables_labels[each.key]
           }
-        },
-        # merge in vnetRoutes if static_routes_config_enabled is true
-        each.value.vwan_security_configuration.static_routes_config_enabled ? {
-          vnetRoutes = {
-            staticRoutesConfig = {
-              vnetLocalRouteOverrideCriteria = each.value.vwan_security_configuration.static_routes_local_route_override_criteria
-            }
-          }
-        } : null
+        } : {}
       )
     }
   })

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      routingConfiguration = each.value.vwan_routing_intent_enabled ? null : {
+      routingConfiguration = each.value.vwan_security_configuration.vwan_routing_intent_enabled ? null : {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
           }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      routingConfiguration = each.value.vwan_routing_intent_enabled ? {} : {
+      routingConfiguration = each.value.vwan_routing_intent_enabled ? null : {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
           }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      each.value.vwan_routing_intent_enabled ? routingConfiguration = {} : routingConfiguration =
+      each.value.vwan_routing_intent_enabled ? "routingConfiguration = {}" : "routingConfiguration =
         {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
@@ -176,7 +176,7 @@ resource "azapi_resource" "vhubconnection" {
             ids    = each.value.vwan_security_configuration.secure_private_traffic ? local.vwan_propagated_noneroutetables_resource_ids[each.key] : local.vwan_propagated_routetables_resource_ids[each.key]
             labels = each.value.vwan_security_configuration.secure_private_traffic ? ["none"] : local.vwan_propagated_routetables_labels[each.key]
           }
-        }
+        }"
     }
   })
 }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -176,8 +176,7 @@ resource "azapi_resource" "vhubconnection" {
             ids    = each.value.vwan_security_configuration.secure_private_traffic ? local.vwan_propagated_noneroutetables_resource_ids[each.key] : local.vwan_propagated_routetables_resource_ids[each.key]
             labels = each.value.vwan_security_configuration.secure_private_traffic ? ["none"] : local.vwan_propagated_routetables_labels[each.key]
           }
-        } : {}
-      )
+        }) : {}
     }
   })
 }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,8 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      each.value.vwan_routing_intent_enabled ? routingConfiguration = {} :
-      routingConfiguration =
+      each.value.vwan_routing_intent_enabled ? routingConfiguration = {} : routingConfiguration =
         {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      routingConfiguration = each.value.vwan_routing_intent_enabled ? merge(
+      routingConfiguration = each.value.vwan_routing_intent_enabled ?
         {
           associatedRouteTable = {
             id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
@@ -176,7 +176,7 @@ resource "azapi_resource" "vhubconnection" {
             ids    = each.value.vwan_security_configuration.secure_private_traffic ? local.vwan_propagated_noneroutetables_resource_ids[each.key] : local.vwan_propagated_routetables_resource_ids[each.key]
             labels = each.value.vwan_security_configuration.secure_private_traffic ? ["none"] : local.vwan_propagated_routetables_labels[each.key]
           }
-        }) : {}
+        } : {}
     }
   })
 }

--- a/modules/virtualnetwork/variables.tf
+++ b/modules/virtualnetwork/variables.tf
@@ -54,7 +54,7 @@ variable "virtual_networks" {
     vwan_security_configuration = optional(object({
       secure_internet_traffic                     = optional(bool, false)
       secure_private_traffic                      = optional(bool, false)
-      each.value.vwan_routing_intent_enabled               = optional(bool, false)
+      vwan_routing_intent_enabled                 = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})

--- a/modules/virtualnetwork/variables.tf
+++ b/modules/virtualnetwork/variables.tf
@@ -54,8 +54,7 @@ variable "virtual_networks" {
     vwan_security_configuration = optional(object({
       secure_internet_traffic                     = optional(bool, false)
       secure_private_traffic                      = optional(bool, false)
-      static_routes_config_enabled                = optional(bool, false)
-      static_routes_local_route_override_criteria = optional(string, "Contains")
+      each.value.vwan_routing_intent_enabled               = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})

--- a/variables.virtualnetwork.tf
+++ b/variables.virtualnetwork.tf
@@ -40,8 +40,7 @@ variable "virtual_networks" {
     vwan_security_configuration = optional(object({
       secure_internet_traffic                     = optional(bool, false)
       secure_private_traffic                      = optional(bool, false)
-      static_routes_config_enabled                = optional(bool, false)
-      static_routes_local_route_override_criteria = optional(string, "Contains")
+      each.value.vwan_routing_intent_enabled      = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})

--- a/variables.virtualnetwork.tf
+++ b/variables.virtualnetwork.tf
@@ -40,7 +40,7 @@ variable "virtual_networks" {
     vwan_security_configuration = optional(object({
       secure_internet_traffic                     = optional(bool, false)
       secure_private_traffic                      = optional(bool, false)
-      each.value.vwan_routing_intent_enabled      = optional(bool, false)
+      vwan_routing_intent_enabled                 = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})


### PR DESCRIPTION
# Overview/summary

Adjusting vHub connection call to be able to facilitate routing intent enabled hub.

## This PR fixes/adds/changes/removes

This PR updates the vhub connection to set the routingConfiguration to null when routingIntent is enabled.

### Breaking changes

None.

## Testing evidence

Validated in customer tenant deployment.

Routing intent is enabled from the platform deployed on the vWAN hub. Connections into the hub "inherit" this configuration for the respective routing.

![image](https://github.com/Azure/terraform-azurerm-lz-vending/assets/16221454/7de07d9d-4148-4d03-963c-f5391bb6c5cf)


When enabling the configuration from the portal the PUT request looks like this:
`{
    "name": "lz1connection",
    "properties": {
        "remoteVirtualNetwork": {
            "id": "/subscriptions/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx/resourceGroups/rg-lz1-networking/providers/Microsoft.Network/virtualNetworks/lz1-vnet"
        },
        "enableInternetSecurity": true,
        "routingConfiguration": {}
    }
}`


## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
