### PR TITLE
fix: routing intent updated variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,9 +818,9 @@ only one of the virtual networks should have `resource_group_creation_enabled` s
 - `vwan_propagated_routetables_labels`: A list of labels of route tables to propagate to the virtual network. [optional - leave empty to use `["default"]`]
 - `vwan_propagated_routetables_resource_ids`: A list of resource IDs of route tables to propagate to the virtual network. [optional - leave empty to use `defaultRouteTable` on hub]
 - `vwan_security_configuration`: A map of security configuration values for VWAN hub connection - see below. [optional - default empty]
-  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `hub_routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
+  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
 
 ### Tags
 

--- a/modules/virtualnetwork/README.md
+++ b/modules/virtualnetwork/README.md
@@ -133,9 +133,9 @@ only one of the virtual networks should have `resource_group_creation_enabled` s
 - `vwan_propagated_routetables_labels`: A list of labels of route tables to propagate to the virtual network. [optional - leave empty to use `["default"]`]
 - `vwan_propagated_routetables_resource_ids`: A list of resource IDs of route tables to propagate to the virtual network. [optional - leave empty to use `defaultRouteTable` on hub]
 - `vwan_security_configuration`: A map of security configuration values for VWAN hub connection - see below. [optional - default empty]
-  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `hub_routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
+  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
 
 ### Tags
 
@@ -177,9 +177,9 @@ map(object({
     vwan_propagated_routetables_labels       = optional(list(string), [])
     vwan_propagated_routetables_resource_ids = optional(list(string), [])
     vwan_security_configuration = optional(object({
-      secure_internet_traffic    = optional(bool, false)
-      secure_private_traffic     = optional(bool, false)
-      hub_routing_intent_enabled = optional(bool, false)
+      secure_internet_traffic = optional(bool, false)
+      secure_private_traffic  = optional(bool, false)
+      routing_intent_enabled  = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -167,7 +167,7 @@ resource "azapi_resource" "vhubconnection" {
       remoteVirtualNetwork = {
         id = local.virtual_network_resource_ids[each.key]
       }
-      routingConfiguration = each.value.vwan_security_configuration.hub_routing_intent_enabled ? null : {
+      routingConfiguration = each.value.vwan_security_configuration.routing_intent_enabled ? null : {
         associatedRouteTable = {
           id = each.value.vwan_associated_routetable_resource_id != "" ? each.value.vwan_associated_routetable_resource_id : "${each.value.vwan_hub_resource_id}/hubRouteTables/defaultRouteTable"
         }

--- a/modules/virtualnetwork/variables.tf
+++ b/modules/virtualnetwork/variables.tf
@@ -52,9 +52,9 @@ variable "virtual_networks" {
     vwan_propagated_routetables_labels       = optional(list(string), [])
     vwan_propagated_routetables_resource_ids = optional(list(string), [])
     vwan_security_configuration = optional(object({
-      secure_internet_traffic    = optional(bool, false)
-      secure_private_traffic     = optional(bool, false)
-      routing_intent_enabled = optional(bool, false)
+      secure_internet_traffic = optional(bool, false)
+      secure_private_traffic  = optional(bool, false)
+      routing_intent_enabled  = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})

--- a/modules/virtualnetwork/variables.tf
+++ b/modules/virtualnetwork/variables.tf
@@ -54,7 +54,7 @@ variable "virtual_networks" {
     vwan_security_configuration = optional(object({
       secure_internet_traffic    = optional(bool, false)
       secure_private_traffic     = optional(bool, false)
-      hub_routing_intent_enabled = optional(bool, false)
+      routing_intent_enabled = optional(bool, false)
     }), {})
 
     tags = optional(map(string), {})
@@ -125,9 +125,9 @@ only one of the virtual networks should have `resource_group_creation_enabled` s
 - `vwan_propagated_routetables_labels`: A list of labels of route tables to propagate to the virtual network. [optional - leave empty to use `["default"]`]
 - `vwan_propagated_routetables_resource_ids`: A list of resource IDs of route tables to propagate to the virtual network. [optional - leave empty to use `defaultRouteTable` on hub]
 - `vwan_security_configuration`: A map of security configuration values for VWAN hub connection - see below. [optional - default empty]
-  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `hub_routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
+  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
 
 ### Tags
 

--- a/tests/virtualnetwork/virtualnetwork_test.go
+++ b/tests/virtualnetwork/virtualnetwork_test.go
@@ -652,7 +652,7 @@ func TestVirtualNetworkCreateValidWithVhubRoutingIntentEnabled(t *testing.T) {
 	primaryvnet["vwan_hub_resource_id"] = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg/providers/Microsoft.Network/virtualHubs/te.st-hub"
 	primaryvnet["vwan_connection_enabled"] = true
 	primaryvnet["vwan_security_configuration"] = map[string]any{
-		"hub_routing_intent_enabled": true,
+		"routing_intent_enabled": true,
 	}
 
 	test, err := setuptest.Dirs(moduleDir, "").WithVars(v).InitPlanShowWithPrepFunc(t, utils.AzureRmAndRequiredProviders)

--- a/variables.virtualnetwork.tf
+++ b/variables.virtualnetwork.tf
@@ -110,9 +110,9 @@ only one of the virtual networks should have `resource_group_creation_enabled` s
 - `vwan_propagated_routetables_labels`: A list of labels of route tables to propagate to the virtual network. [optional - leave empty to use `["default"]`]
 - `vwan_propagated_routetables_resource_ids`: A list of resource IDs of route tables to propagate to the virtual network. [optional - leave empty to use `defaultRouteTable` on hub]
 - `vwan_security_configuration`: A map of security configuration values for VWAN hub connection - see below. [optional - default empty]
-  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `vwan_routing_intent_enabled`. [optional - default `false`]
-  - `hub_routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
+  - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
+  - `routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. Not compatible with `secure_internet_traffic` or `secure_private_traffic`. [optional - default `false`]
 
 ### Tags
 


### PR DESCRIPTION
# Overview/summary

This PR fixes the routing intent variable naming across the module.

## This PR fixes/adds/changes/removes

Fixes correct enabling routing intent when deploying a landing zone on a routing intent enabled vWAN hub

### Breaking changes

None

## Testing evidence


## As part of this pull request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
