### PR TITLE
feat: enable unidirectional vnet peering

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -16,7 +16,7 @@ For *Git Bash for Windows*, at the step of "Adjusting your PATH environment", pl
 
 Or, use [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/install)
 
-### Setup on WSL
+### Setup on WSL with Ubuntu 22.04
 
 #### Install Go and Make
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -31,7 +31,7 @@ export PATH=$PATH:$GOPATH/bin
 ```
 5. Type <kbd>Ctrl</kbd> + <kbd>x</kbd> to save, then enter <kbd>y</kbd> and hit <kbd>enter</kbd>
 5. Run `source ~/.profile`
-6. Run `sudo apt-get update apt-get install make`
+6. Run `sudo apt-get update && apt-get install make`
 
 #### Install Terraform
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -24,11 +24,12 @@ Or, use [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/ins
 2. Run `rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz`
 3. Run `sudo nano ~/.profile`
 4. Add the following lines at the end of the file:
-```
+```bash
 export PATH=$PATH:/usr/local/go/bin
 export GOPATH=$HOME/go/bin
 export PATH=$PATH:$GOPATH/bin
 ```
+5. Type <kbd>Ctrl</kbd> + <kbd>x</kbd> to save, then enter <kbd>y</kbd> and hit <kbd>enter</kbd>
 5. Run `source ~/.profile`
 6. Run `sudo apt-get update apt-get install make`
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -16,6 +16,32 @@ For *Git Bash for Windows*, at the step of "Adjusting your PATH environment", pl
 
 Or, use [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/install)
 
+### Setup on WSL
+
+#### Install Go and Make
+
+1. Run `curl -L https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -o go1.21.0.linux-amd64.tar.gz` (replace with a different version of go if desired)
+2. Run `rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz`
+3. Run `sudo nano ~/.profile`
+4. Add the following lines at the end of the file:
+```
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=$HOME/go/bin
+export PATH=$PATH:$GOPATH/bin
+```
+5. Run `source ~/.profile`
+6. Run `sudo apt-get update apt-get install make`
+
+#### Install Terraform
+
+1. Follow these instructions `https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli`.
+
+#### Setup Project Tools
+
+1. Clone the repository
+2. Navigate to the root of the repository
+3. Run `make tools`
+
 ## Terratest
 
 We use [Terratest](https://terratest.gruntwork.io/) to run the unit and deployment testing for the module. Therefore, if you wish to work on the module, you'll first need [Go](http://www.golang.org) installed on your machine.

--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ Description: A map of the virtual networks to create. The map key must be known 
 The following values configure bi-directional hub & spoke peering for the given virtual network.
 
 - `hub_peering_enabled`: Whether to enable hub peering. [optional]
+- `hub_peering_direction`: The direction of the peering. [optional - allowed values are: `tohub`, `fromhub` or `both` - default `both`]
 - `hub_network_resource_id`: The resource ID of the hub network to peer with. [optional - but required if hub\_peering\_enabled is `true`]
 - `hub_peering_name_tohub`: The name of the peering to the hub network. [optional - leave empty to use calculated name]
 - `hub_peering_name_fromhub`: The name of the peering from the hub network. [optional - leave empty to use calculated name]
@@ -843,6 +844,7 @@ map(object({
 
     hub_network_resource_id         = optional(string, "")
     hub_peering_enabled             = optional(bool, false)
+    hub_peering_direction           = optional(string, "both")
     hub_peering_name_tohub          = optional(string, "")
     hub_peering_name_fromhub        = optional(string, "")
     hub_peering_use_remote_gateways = optional(bool, true)

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "3.4.0"
+    "module_version": "3.5.0"
   }
 }

--- a/modules/virtualnetwork/README.md
+++ b/modules/virtualnetwork/README.md
@@ -158,6 +158,7 @@ map(object({
 
     hub_network_resource_id         = optional(string, "")
     hub_peering_enabled             = optional(bool, false)
+    hub_peering_direction           = optional(string, "both")
     hub_peering_name_tohub          = optional(string, "")
     hub_peering_name_fromhub        = optional(string, "")
     hub_peering_use_remote_gateways = optional(bool, true)

--- a/modules/virtualnetwork/locals.tf
+++ b/modules/virtualnetwork/locals.tf
@@ -10,6 +10,9 @@ locals {
     for k, v in var.virtual_networks : k => "${local.subscription_resource_id}/resourceGroups/${v.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${v.name}"
   }
 
+  # allowed values for peering direction
+  valid_peering_directions = ["tohub", "fromhub", "both"]
+
   # virtual_networks_hub_peering_map is a map of the virtual network hub peerings
 
   # hub_peering_map is a map of the virtual network hub peerings for those networks
@@ -28,6 +31,7 @@ locals {
         this_resource_id   = v.hub_network_resource_id
         remote_resource_id = azapi_resource.vnet[k].id
       }
+      direction = contains(local.valid_peering_directions, coalesce(v.hub_peering_direction, "both")) ? coalesce(v.hub_peering_direction, "both") : "both"
     } if v.hub_peering_enabled
   }
 

--- a/modules/virtualnetwork/locals.tf
+++ b/modules/virtualnetwork/locals.tf
@@ -10,8 +10,13 @@ locals {
     for k, v in var.virtual_networks : k => "${local.subscription_resource_id}/resourceGroups/${v.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${v.name}"
   }
 
+  # peering direction constansts
+  peering_direction_both    = "both"
+  peering_direction_tohub   = "tohub"
+  peering_direction_fromhub = "fromhub"
+
   # allowed values for peering direction
-  valid_peering_directions = ["tohub", "fromhub", "both"]
+  valid_peering_directions = [local.peering_direction_tohub, local.peering_direction_fromhub, local.peering_direction_both]
 
   # virtual_networks_hub_peering_map is a map of the virtual network hub peerings
 
@@ -31,6 +36,8 @@ locals {
         this_resource_id   = v.hub_network_resource_id
         remote_resource_id = azapi_resource.vnet[k].id
       }
+      peering_direction   = contains(local.valid_peering_directions, coalesce(lower(v.hub_peering_direction), local.peering_direction_both)) ? coalesce(lower(v.hub_peering_direction), local.peering_direction_both) : local.peering_direction_both
+      use_remote_gateways = v.hub_peering_use_remote_gateways
     } if v.hub_peering_enabled
   }
 

--- a/modules/virtualnetwork/locals.tf
+++ b/modules/virtualnetwork/locals.tf
@@ -31,7 +31,6 @@ locals {
         this_resource_id   = v.hub_network_resource_id
         remote_resource_id = azapi_resource.vnet[k].id
       }
-      direction = contains(local.valid_peering_directions, coalesce(v.hub_peering_direction, "both")) ? coalesce(v.hub_peering_direction, "both") : "both"
     } if v.hub_peering_enabled
   }
 

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -98,7 +98,7 @@ resource "azapi_update_resource" "vnet" {
 # azapi_resource.peering_hub_outbound creates one-way peering from the spoke to the supplied hub virtual network.
 # They are not created if the hub virtual network is an empty string.
 resource "azapi_resource" "peering_hub_outbound" {
-  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.direction != "fromhub" }
+  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.hub_peering_direction != "fromhub" }
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-08-01"
   parent_id = local.hub_peering_map[each.key]["outbound"].this_resource_id
   name      = local.hub_peering_map[each.key]["outbound"].name
@@ -118,7 +118,7 @@ resource "azapi_resource" "peering_hub_outbound" {
 # azapi_resource.peering_hub_inbound creates one-way peering from the supplied hub network to the spoke.
 # They are not created if the hub virtual network is an empty string.
 resource "azapi_resource" "peering_hub_inbound" {
-  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.direction != "tohub" }
+  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.hub_peering_direction != "tohub" }
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-08-01"
   parent_id = local.hub_peering_map[each.key]["inbound"].this_resource_id
   name      = local.hub_peering_map[each.key]["inbound"].name

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -98,19 +98,19 @@ resource "azapi_update_resource" "vnet" {
 # azapi_resource.peering_hub_outbound creates one-way peering from the spoke to the supplied hub virtual network.
 # They are not created if the hub virtual network is an empty string.
 resource "azapi_resource" "peering_hub_outbound" {
-  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.hub_peering_direction != "fromhub" }
+  for_each  = { for k, v in local.hub_peering_map : k => v if v.peering_direction != local.peering_direction_fromhub }
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-08-01"
-  parent_id = local.hub_peering_map[each.key]["outbound"].this_resource_id
-  name      = local.hub_peering_map[each.key]["outbound"].name
+  parent_id = each.value["outbound"].this_resource_id
+  name      = each.value["outbound"].name
   body = jsonencode({
     properties = {
       remoteVirtualNetwork = {
-        id = local.hub_peering_map[each.key]["outbound"].remote_resource_id
+        id = each.value["outbound"].remote_resource_id
       }
       allowVirtualNetworkAccess = true
       allowForwardedTraffic     = true
       allowGatewayTransit       = false
-      useRemoteGateways         = each.value.hub_peering_use_remote_gateways
+      useRemoteGateways         = each.value.use_remote_gateways
     }
   })
 }
@@ -118,19 +118,19 @@ resource "azapi_resource" "peering_hub_outbound" {
 # azapi_resource.peering_hub_inbound creates one-way peering from the supplied hub network to the spoke.
 # They are not created if the hub virtual network is an empty string.
 resource "azapi_resource" "peering_hub_inbound" {
-  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.hub_peering_direction != "tohub" }
+  for_each  = { for k, v in local.hub_peering_map : k => v if v.peering_direction != local.peering_direction_tohub }
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-08-01"
-  parent_id = local.hub_peering_map[each.key]["inbound"].this_resource_id
-  name      = local.hub_peering_map[each.key]["inbound"].name
+  parent_id = each.value["inbound"].this_resource_id
+  name      = each.value["inbound"].name
   body = jsonencode({
     properties = {
       remoteVirtualNetwork = {
-        id = local.hub_peering_map[each.key]["inbound"].remote_resource_id
+        id = each.value["inbound"].remote_resource_id
       }
       allowVirtualNetworkAccess = true
       allowForwardedTraffic     = true
       allowGatewayTransit       = true
-      useRemoteGateways         = false
+      useRemoteGateways         = each.value.use_remote_gateways
     }
   })
 }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -98,7 +98,7 @@ resource "azapi_update_resource" "vnet" {
 # azapi_resource.peering_hub_outbound creates one-way peering from the spoke to the supplied hub virtual network.
 # They are not created if the hub virtual network is an empty string.
 resource "azapi_resource" "peering_hub_outbound" {
-  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled }
+  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.direction != "fromhub" }
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-08-01"
   parent_id = local.hub_peering_map[each.key]["outbound"].this_resource_id
   name      = local.hub_peering_map[each.key]["outbound"].name
@@ -118,7 +118,7 @@ resource "azapi_resource" "peering_hub_outbound" {
 # azapi_resource.peering_hub_inbound creates one-way peering from the supplied hub network to the spoke.
 # They are not created if the hub virtual network is an empty string.
 resource "azapi_resource" "peering_hub_inbound" {
-  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled }
+  for_each  = { for k, v in var.virtual_networks : k => v if v.hub_peering_enabled && v.direction != "tohub" }
   type      = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-08-01"
   parent_id = local.hub_peering_map[each.key]["inbound"].this_resource_id
   name      = local.hub_peering_map[each.key]["inbound"].name

--- a/modules/virtualnetwork/variables.tf
+++ b/modules/virtualnetwork/variables.tf
@@ -33,6 +33,7 @@ variable "virtual_networks" {
 
     hub_network_resource_id         = optional(string, "")
     hub_peering_enabled             = optional(bool, false)
+    hub_peering_direction           = optional(string, "both")
     hub_peering_name_tohub          = optional(string, "")
     hub_peering_name_fromhub        = optional(string, "")
     hub_peering_use_remote_gateways = optional(bool, true)

--- a/tests/virtualnetwork/virtualnetworkDeploy_test.go
+++ b/tests/virtualnetwork/virtualnetworkDeploy_test.go
@@ -135,7 +135,7 @@ func TestDeployVirtualNetworkValidUniDirectionalVnetPeering(t *testing.T) {
 	t.Parallel()
 
 	utils.PreCheckDeployTests(t)
-	testDir := "testdata/" + t.Name()
+	testDir := ""
 	v, err := getValidInputVariables()
 	require.NoErrorf(t, err, "could not generate valid input variables, %s", err)
 	primaryvnet := v["virtual_networks"].(map[string]map[string]any)["primary"]

--- a/tests/virtualnetwork/virtualnetworkDeploy_test.go
+++ b/tests/virtualnetwork/virtualnetworkDeploy_test.go
@@ -151,7 +151,7 @@ func TestDeployVirtualNetworkValidUniDirectionalVnetPeering(t *testing.T) {
 	require.NoError(t, err)
 	defer test.Cleanup()
 
-	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(14).ErrorIsNil(t)
+	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(12).ErrorIsNil(t)
 
 	resources := []string{
 		"module.virtualnetwork_test.azapi_resource.vnet[\"primary\"]",

--- a/tests/virtualnetwork/virtualnetworkDeploy_test.go
+++ b/tests/virtualnetwork/virtualnetworkDeploy_test.go
@@ -129,6 +129,47 @@ func TestDeployVirtualNetworkValidVnetPeering(t *testing.T) {
 	test.ApplyIdempotent().ErrorIsNil(t)
 }
 
+// TestDeployVirtualNetworkValidUniDirectionalVnetPeering tests the deployment of a virtual network
+// with unidirectional peering to a hub virtual network.
+func TestDeployVirtualNetworkValidUniDirectionalVnetPeering(t *testing.T) {
+	t.Parallel()
+
+	utils.PreCheckDeployTests(t)
+	testDir := "testdata/" + t.Name()
+	v, err := getValidInputVariables()
+	require.NoErrorf(t, err, "could not generate valid input variables, %s", err)
+	primaryvnet := v["virtual_networks"].(map[string]map[string]any)["primary"]
+	secondaryvnet := v["virtual_networks"].(map[string]map[string]any)["secondary"]
+	primaryvnet["hub_peering_enabled"] = true
+	primaryvnet["hub_peering_direction"] = "fromhub"
+	secondaryvnet["hub_peering_enabled"] = true
+	secondaryvnet["hub_peering_direction"] = "tohub"
+	primaryvnet["hub_peering_use_remote_gateways"] = false
+	secondaryvnet["hub_peering_use_remote_gateways"] = false
+
+	test, err := setuptest.Dirs(moduleDir, testDir).WithVars(v).InitPlanShowWithPrepFunc(t, utils.AzureRmAndRequiredProviders)
+	require.NoError(t, err)
+	defer test.Cleanup()
+
+	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(14).ErrorIsNil(t)
+
+	resources := []string{
+		"module.virtualnetwork_test.azapi_resource.vnet[\"primary\"]",
+		"module.virtualnetwork_test.azapi_resource.vnet[\"secondary\"]",
+		"module.virtualnetwork_test.azapi_resource.peering_hub_inbound[\"primary\"]",
+		"module.virtualnetwork_test.azapi_resource.peering_hub_outbound[\"secondary\"]",
+		"module.virtualnetwork_test.azapi_update_resource.vnet[\"primary\"]",
+		"module.virtualnetwork_test.azapi_update_resource.vnet[\"secondary\"]",
+	}
+	for _, r := range resources {
+		check.InPlan(test.PlanStruct).That(r).Exists().ErrorIsNil(t)
+	}
+
+	// defer terraform destroy with retry
+	defer test.DestroyRetry(setuptest.DefaultRetry) //nolint:errcheck
+	test.ApplyIdempotent().ErrorIsNil(t)
+}
+
 // TestDeployVirtualNetworkValidVhubConnection tests the deployment of a virtual network
 // with a virtual WAN connection.
 func TestDeployVirtualNetworkValidVhubConnection(t *testing.T) {

--- a/tests/virtualnetwork/virtualnetwork_test.go
+++ b/tests/virtualnetwork/virtualnetwork_test.go
@@ -354,8 +354,8 @@ func TestVirtualNetworkCreateValidWithOnlyToHubPeering(t *testing.T) {
 	require.NoError(t, err)
 	defer test.Cleanup()
 
-	// We want 10 resources here, 2 more than the TestVirtualNetworkCreateValid test
-	// The additional two are the inbound & outbound peering
+	// We want 9 resources here, 1 more than the TestVirtualNetworkCreateValid test
+	// The additional one is the outbound peering
 	resources := []string{
 		"azapi_resource.rg[\"primary-rg\"]",
 		"azapi_resource.rg[\"secondary-rg\"]",

--- a/tests/virtualnetwork/virtualnetwork_test.go
+++ b/tests/virtualnetwork/virtualnetwork_test.go
@@ -335,6 +335,84 @@ func TestVirtualNetworkCreateValidWithHubPeeringCustomNames(t *testing.T) {
 	check.InPlan(test.PlanStruct).That(inbound).Key("name").HasValue(primaryvnet["hub_peering_name_fromhub"]).ErrorIsNil(t)
 }
 
+// TestVirtualNetworkCreateValidWithOnlyToHubPeering tests the creation of a plan that
+// creates a virtual network with unidirectional peering to a hub, with custom names for peers.
+func TestVirtualNetworkCreateValidWithOnlyToHubPeering(t *testing.T) {
+	t.Parallel()
+
+	v := getMockInputVariables()
+
+	// Enable hub network peering to primary vnet in test mock input variables
+	primaryvnet := v["virtual_networks"].(map[string]map[string]any)["primary"]
+	primaryvnet["hub_network_resource_id"] = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/testvnet2"
+	primaryvnet["hub_peering_enabled"] = true
+	primaryvnet["hub_peering_direction"] = "tohub"
+	primaryvnet["hub_peering_name_tohub"] = "test-tohub"
+	primaryvnet["hub_peering_name_fromhub"] = "test-fromhub"
+
+	test, err := setuptest.Dirs(moduleDir, "").WithVars(v).InitPlanShowWithPrepFunc(t, utils.AzureRmAndRequiredProviders)
+	require.NoError(t, err)
+	defer test.Cleanup()
+
+	// We want 10 resources here, 2 more than the TestVirtualNetworkCreateValid test
+	// The additional two are the inbound & outbound peering
+	resources := []string{
+		"azapi_resource.rg[\"primary-rg\"]",
+		"azapi_resource.rg[\"secondary-rg\"]",
+		"azapi_resource.vnet[\"primary\"]",
+		"azapi_resource.vnet[\"secondary\"]",
+		"azapi_update_resource.vnet[\"primary\"]",
+		"azapi_update_resource.vnet[\"secondary\"]",
+		"azapi_resource.rg_lock[\"primary-rg\"]",
+		"azapi_resource.rg_lock[\"secondary-rg\"]",
+		"azapi_resource.peering_hub_outbound[\"primary\"]",
+	}
+	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(len(resources)).ErrorIsNilFatal(t)
+
+	for _, r := range resources {
+		check.InPlan(test.PlanStruct).That(r).Exists().ErrorIsNil(t)
+	}
+}
+
+// TestVirtualNetworkCreateValidWithOnlyFromHubPeering tests the creation of a plan that
+// creates a virtual network with unidirectional peering from a hub, with custom names for peers.
+func TestVirtualNetworkCreateValidWithOnlyFromHubPeering(t *testing.T) {
+	t.Parallel()
+
+	v := getMockInputVariables()
+
+	// Enable hub network peering to primary vnet in test mock input variables
+	primaryvnet := v["virtual_networks"].(map[string]map[string]any)["primary"]
+	primaryvnet["hub_network_resource_id"] = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/testvnet2"
+	primaryvnet["hub_peering_enabled"] = true
+	primaryvnet["hub_peering_direction"] = "fromhub"
+	primaryvnet["hub_peering_name_tohub"] = "test-tohub"
+	primaryvnet["hub_peering_name_fromhub"] = "test-fromhub"
+
+	test, err := setuptest.Dirs(moduleDir, "").WithVars(v).InitPlanShowWithPrepFunc(t, utils.AzureRmAndRequiredProviders)
+	require.NoError(t, err)
+	defer test.Cleanup()
+
+	// We want 10 resources here, 2 more than the TestVirtualNetworkCreateValid test
+	// The additional two are the inbound & outbound peering
+	resources := []string{
+		"azapi_resource.rg[\"primary-rg\"]",
+		"azapi_resource.rg[\"secondary-rg\"]",
+		"azapi_resource.vnet[\"primary\"]",
+		"azapi_resource.vnet[\"secondary\"]",
+		"azapi_update_resource.vnet[\"primary\"]",
+		"azapi_update_resource.vnet[\"secondary\"]",
+		"azapi_resource.rg_lock[\"primary-rg\"]",
+		"azapi_resource.rg_lock[\"secondary-rg\"]",
+		"azapi_resource.peering_hub_inbound[\"primary\"]",
+	}
+	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(len(resources)).ErrorIsNilFatal(t)
+
+	for _, r := range resources {
+		check.InPlan(test.PlanStruct).That(r).Exists().ErrorIsNil(t)
+	}
+}
+
 // TestVirtualNetworkCreateValidWithPeeringUseRemoteGatewaysDisabled
 // tests the creation of a plan that configured the outbound peering
 // with useRemoteGateways disabled.

--- a/variables.virtualnetwork.tf
+++ b/variables.virtualnetwork.tf
@@ -19,6 +19,7 @@ variable "virtual_networks" {
 
     hub_network_resource_id         = optional(string, "")
     hub_peering_enabled             = optional(bool, false)
+    hub_peering_direction           = optional(string, "both")
     hub_peering_name_tohub          = optional(string, "")
     hub_peering_name_fromhub        = optional(string, "")
     hub_peering_use_remote_gateways = optional(bool, true)
@@ -75,6 +76,7 @@ A map of the virtual networks to create. The map key must be known at the plan s
 The following values configure bi-directional hub & spoke peering for the given virtual network.
 
 - `hub_peering_enabled`: Whether to enable hub peering. [optional]
+- `hub_peering_direction`: The direction of the peering. [optional - allowed values are: `tohub`, `fromhub` or `both` - default `both`]
 - `hub_network_resource_id`: The resource ID of the hub network to peer with. [optional - but required if hub_peering_enabled is `true`]
 - `hub_peering_name_tohub`: The name of the peering to the hub network. [optional - leave empty to use calculated name]
 - `hub_peering_name_fromhub`: The name of the peering from the hub network. [optional - leave empty to use calculated name]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

This change adds a new attribute to the vnet variable to support unidirectional peering.

## This PR fixes/adds/changes/removes

N/A

### Breaking changes

None, defaults to `both` which was the previous behaviour.

## Testing evidence

Unit tests have been added to cover both cases.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [x] Created unit and deployment tests and provided evidence.
- [x] Updated relevant and associated documentation.
