### PR TITLE
fix(subscription): add `time_sleep` and `azapi_resoure_action` for subscription association

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,21 @@ map(object({
 
 Default: `{}`
 
+### <a name="input_wait_for_subscription_before_subscription_operations"></a> [wait\_for\_subscription\_before\_subscription\_operations](#input\_wait\_for\_subscription\_before\_subscription\_operations)
+
+Description: The duration to wait after vending a subscription before performing subscription operations.
+
+Type:
+
+```hcl
+object({
+    create  = optional(string, "30s")
+    destroy = optional(string, "0s")
+  })
+```
+
+Default: `{}`
+
 ## Resources
 
 The following resources are used by this module:

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.7.0)
 
+- <a name="requirement_time"></a> [time](#requirement\_time) (>= 0.9.1)
+
 ## Modules
 
 The following Modules are called:

--- a/main.subscription.tf
+++ b/main.subscription.tf
@@ -5,15 +5,16 @@ module "subscription" {
   source = "./modules/subscription"
   count  = (var.subscription_id != "" && var.subscription_update_existing) || var.subscription_alias_enabled || var.subscription_management_group_association_enabled ? 1 : 0
 
-  subscription_alias_enabled                        = var.subscription_alias_enabled
-  subscription_alias_name                           = var.subscription_alias_name
-  subscription_billing_scope                        = var.subscription_billing_scope
-  subscription_display_name                         = var.subscription_display_name
-  subscription_id                                   = var.subscription_id
-  subscription_management_group_association_enabled = var.subscription_management_group_association_enabled
-  subscription_management_group_id                  = var.subscription_management_group_id
-  subscription_tags                                 = var.subscription_tags
-  subscription_use_azapi                            = var.subscription_use_azapi
-  subscription_update_existing                      = var.subscription_update_existing
-  subscription_workload                             = var.subscription_workload
+  subscription_alias_enabled                           = var.subscription_alias_enabled
+  subscription_alias_name                              = var.subscription_alias_name
+  subscription_billing_scope                           = var.subscription_billing_scope
+  subscription_display_name                            = var.subscription_display_name
+  subscription_id                                      = var.subscription_id
+  subscription_management_group_association_enabled    = var.subscription_management_group_association_enabled
+  subscription_management_group_id                     = var.subscription_management_group_id
+  subscription_tags                                    = var.subscription_tags
+  subscription_use_azapi                               = var.subscription_use_azapi
+  subscription_update_existing                         = var.subscription_update_existing
+  subscription_workload                                = var.subscription_workload
+  wait_for_subscription_before_subscription_operations = var.wait_for_subscription_before_subscription_operations
 }

--- a/modules/subscription/README.md
+++ b/modules/subscription/README.md
@@ -202,15 +202,32 @@ Type: `string`
 
 Default: `""`
 
+### <a name="input_wait_for_subscription_before_subscription_operations"></a> [wait\_for\_subscription\_before\_subscription\_operations](#input\_wait\_for\_subscription\_before\_subscription\_operations)
+
+Description: The duration to wait after vending a subscription before performing subscription operations.
+
+Type:
+
+```hcl
+object({
+    create  = optional(string, "30s")
+    destroy = optional(string, "0s")
+  })
+```
+
+Default: `{}`
+
 ## Resources
 
 The following resources are used by this module:
 
 - [azapi_resource.subscription](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource_action.subscription_association](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_resource_action.subscription_rename](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azapi_update_resource.subscription_tags](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_management_group_subscription_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) (resource)
 - [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) (resource)
+- [time_sleep.wait_for_subscription_before_subscription_operations](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 
 ## Outputs
 

--- a/modules/subscription/README.md
+++ b/modules/subscription/README.md
@@ -37,6 +37,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.7.0)
 
+- <a name="requirement_time"></a> [time](#requirement\_time) (>= 0.9.1)
+
 ## Modules
 
 No modules.

--- a/modules/subscription/terraform.tf
+++ b/modules/subscription/terraform.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "Azure/azapi"
       version = ">= 1.3.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1"
+    }
   }
 }

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -173,3 +173,14 @@ If enabled, the following must also be supplied:
 - `subscription_id`
 DESCRIPTION
 }
+
+variable "wait_for_subscription_before_subscription_operations" {
+  type = object({
+    create  = optional(string, "30s")
+    destroy = optional(string, "0s")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+The duration to wait after vending a subscription before performing subscription operations.
+DESCRIPTION
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "azure/azapi"
       version = ">= 1.4.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1"
+    }
   }
 }

--- a/tests/subscription/subscriptionDeploy_test.go
+++ b/tests/subscription/subscriptionDeploy_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var billingScope = os.Getenv("AZURE_BILLING_SCOPE")
+var tenantId = os.Getenv("AZURE_TENANT_ID")
 
 // TestDeploySubscriptionAliasValid tests the deployment of a subscription alias
 // with valid input variables.
@@ -71,7 +72,7 @@ func TestDeploySubscriptionAliasValidAzApi(t *testing.T) {
 	require.NoError(t, err)
 	defer test.Cleanup()
 
-	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(3).ErrorIsNil(t)
+	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(4).ErrorIsNil(t)
 
 	// Defer the cleanup of the subscription alias to the end of the test.
 	// Should be run after the Terraform destroy.
@@ -185,6 +186,10 @@ func TestDeploySubscriptionAliasManagementGroupValidAzApi(t *testing.T) {
 
 	err = azureutils.IsSubscriptionInManagementGroup(t, u, v["subscription_management_group_id"].(string))
 	assert.NoErrorf(t, err, "subscription %s is not in management group %s", sid, v["subscription_management_group_id"].(string))
+
+	if err := azureutils.SetSubscriptionManagementGroup(u, tenantId); err != nil {
+		t.Logf("cannot move subscription to tenant root group: %v", err)
+	}
 }
 
 // getValidInputVariables returns a set of valid input variables that can be used and modified for testing scenarios.

--- a/tests/subscription/subscription_test.go
+++ b/tests/subscription/subscription_test.go
@@ -48,6 +48,7 @@ func TestSubscriptionAliasCreateValidAzApi(t *testing.T) {
 		"azapi_resource.subscription[0]",
 		"azapi_resource_action.subscription_rename[0]",
 		"azapi_update_resource.subscription_tags[0]",
+		"time_sleep.wait_for_subscription_before_subscription_operations[0]",
 	}
 
 	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(len(resources)).ErrorIsNil(t)
@@ -105,7 +106,8 @@ func TestSubscriptionAliasCreateValidWithManagementGroupAzApi(t *testing.T) {
 		"azapi_resource.subscription[0]",
 		"azapi_resource_action.subscription_rename[0]",
 		"azapi_update_resource.subscription_tags[0]",
-		"azurerm_management_group_subscription_association.this[0]",
+		"azapi_resource_action.subscription_association[0]",
+		"time_sleep.wait_for_subscription_before_subscription_operations[0]",
 	}
 
 	check.InPlan(test.PlanStruct).NumberOfResourcesEquals(len(resources)).ErrorIsNil(t)

--- a/variables.subscription.tf
+++ b/variables.subscription.tf
@@ -186,3 +186,14 @@ If enabled, the following must also be supplied:
 - `subscription_id`
 DESCRIPTION
 }
+
+variable "wait_for_subscription_before_subscription_operations" {
+  type = object({
+    create  = optional(string, "30s")
+    destroy = optional(string, "0s")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+The duration to wait after vending a subscription before performing subscription operations.
+DESCRIPTION
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. fixes race conditions and eventual consistency errors with using azapi to vend subscriptions.

### Breaking changes


## Testing evidence
<details>
<summary>Click to expand</summary>

```
=== RUN   TestDeploySubscriptionAliasManagementGroupValidAzApi
=== PAUSE TestDeploySubscriptionAliasManagementGroupValidAzApi
=== CONT  TestDeploySubscriptionAliasManagementGroupValidAzApi
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:10Z test_structure.go:130: Copied terraform folder ../../modules/subscription/testdata/TestDeploySubscriptionAliasManagementGroupValid to /tmp/TestDeploySubscriptionAliasManagementGroupValidAzApi2932116775/subscription/testdata/TestDeploySubscriptionAliasManagementGroupValid
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:10Z retry.go:91: terraform [init -upgrade=false -no-color]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:35Z retry.go:91: terraform [plan -input=false -lock=false -var subscription_alias_enabled=true -var subscription_management_group_id=testdeploy-e7e4ecfb -var subscription_management_group_association_enabled=true -var subscription_alias_name=testdeploy-e7e4ecfb -var subscription_display_name=testdeploy-e7e4ecfb -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -no-color -lock=true -out=tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:50Z logger.go:51: logging sample: [      + name                      = "testdeploy-e7e4ecfb"]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:50Z logger.go:51: logging sample: [  + resource "azapi_resource_action" "subscription_rename" {]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:50Z logger.go:51: logging sample: [    terraform apply "tfplan"]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:50Z retry.go:91: terraform [show -no-color -json tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:45:51Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=true tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:47:32Z retry.go:91: terraform [output -no-color -json subscription_id]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:47:35Z retry.go:91: is subscription in management group
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:47:41Z retry.go:91: terraform [destroy -auto-approve -input=false -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_management_group_id=testdeploy-e7e4ecfb -var subscription_management_group_association_enabled=true -var subscription_alias_name=testdeploy-e7e4ecfb -var subscription_display_name=testdeploy-e7e4ecfb -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -no-color -lock=true]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:47:53Z logger.go:51: logging sample: [module.subscription_test.azapi_update_resource.subscription_tags[0]: Refreshing state... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default]]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:47:54Z logger.go:51: logging sample: [      - parent_id                 = "/" -> null]
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:47:54Z logger.go:51: logging sample: [      - type                    = "Microsoft.Resources/tags@2022-09-01" -> null]
    subscription.go:20: cancelling subscription b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3
    subscription.go:40: removing 0 resource groups for subscription b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3
    subscription.go:52: removed 0 resource groups for subscription b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3
TestDeploySubscriptionAliasManagementGroupValidAzApi 2023-12-06T16:48:11Z retry.go:91: cancel subscription
    subscription.go:77: cancelled subscription b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [init -upgrade=false -no-color]
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Initializing the backend...
TestDeploySubscriptionAliasManagementGroupValidAzApi: Initializing modules...
TestDeploySubscriptionAliasManagementGroupValidAzApi: - subscription_test in ../..
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Initializing provider plugins...
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Reusing previous version of azure/azapi from the dependency lock file
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Reusing previous version of hashicorp/azurerm from the dependency lock file
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Finding hashicorp/time versions matching ">= 0.9.1"...
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Installing hashicorp/time v0.10.0...
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Installed hashicorp/time v0.10.0 (signed by HashiCorp)
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Installing azure/azapi v1.9.0...
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Installed azure/azapi v1.9.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Installing hashicorp/azurerm v3.72.0...
TestDeploySubscriptionAliasManagementGroupValidAzApi: - Installed hashicorp/azurerm v3.72.0 (signed by HashiCorp)
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Partner and community providers are signed by their developers.
TestDeploySubscriptionAliasManagementGroupValidAzApi: If you'd like to know more about provider signing, you can read about it here:
TestDeploySubscriptionAliasManagementGroupValidAzApi: https://www.terraform.io/docs/cli/plugins/signing.html
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform has made some changes to the provider dependency selections recorded
TestDeploySubscriptionAliasManagementGroupValidAzApi: in the .terraform.lock.hcl file. Review those changes and commit them to your
TestDeploySubscriptionAliasManagementGroupValidAzApi: version control system if they represent changes you intended to make.
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform has been successfully initialized!
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: You may now begin working with Terraform. Try running "terraform plan" to see
TestDeploySubscriptionAliasManagementGroupValidAzApi: any changes that are required for your infrastructure. All Terraform commands
TestDeploySubscriptionAliasManagementGroupValidAzApi: should now work.
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: If you ever set or change modules or backend configuration for Terraform,
TestDeploySubscriptionAliasManagementGroupValidAzApi: rerun this command to reinitialize your working directory. If you forget, other
TestDeploySubscriptionAliasManagementGroupValidAzApi: commands will detect it and remind you to do so if necessary.
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [plan -input=false -lock=false -var subscription_alias_enabled=true -var subscription_management_group_id=testdeploy-e7e4ecfb -var subscription_management_group_association_enabled=true -var subscription_alias_name=testdeploy-e7e4ecfb -var subscription_display_name=testdeploy-e7e4ecfb -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -no-color -lock=true -out=tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform used the selected providers to generate the following execution
TestDeploySubscriptionAliasManagementGroupValidAzApi: plan. Resource actions are indicated with the following symbols:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + create
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform will perform the following actions:
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # azapi_resource.mg will be created
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + resource "azapi_resource" "mg" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + body                      = jsonencode({})
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + id                        = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + ignore_casing             = false
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + ignore_missing_property   = true
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + location                  = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + name                      = "testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + output                    = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + parent_id                 = "/"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + removing_special_chars    = false
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + schema_validation_enabled = true
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + tags                      = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + type                      = "Microsoft.Management/managementGroups@2021-04-01"
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_resource.subscription[0] will be created
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + resource "azapi_resource" "subscription" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + body                      = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               + properties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   + additionalProperties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                       + managementGroupId = "/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                       + tags              = {}
TestDeploySubscriptionAliasManagementGroupValidAzApi:                     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   + billingScope         = "/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   + displayName          = "testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   + workload             = "DevTest"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                 }
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         )
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + id                        = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + ignore_casing             = false
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + ignore_missing_property   = true
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + location                  = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + name                      = "testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + output                    = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + parent_id                 = "/"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + removing_special_chars    = false
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + response_export_values    = [
TestDeploySubscriptionAliasManagementGroupValidAzApi:           + "properties.subscriptionId",
TestDeploySubscriptionAliasManagementGroupValidAzApi:         ]
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + schema_validation_enabled = true
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + tags                      = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + type                      = "Microsoft.Subscription/aliases@2021-10-01"
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_resource_action.subscription_association[0] will be created
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + resource "azapi_resource_action" "subscription_association" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + id          = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + method      = "PUT"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + output      = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + resource_id = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + type        = "Microsoft.Management/managementGroups/subscriptions@2021-04-01"
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_resource_action.subscription_rename[0] will be created
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + resource "azapi_resource_action" "subscription_rename" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + action      = "providers/Microsoft.Subscription/rename"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + body        = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               + subscriptionName = "testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         )
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + id          = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + method      = "POST"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + output      = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + resource_id = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + type        = "Microsoft.Resources/subscriptions@2021-10-01"
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_update_resource.subscription_tags[0] will be created
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + resource "azapi_update_resource" "subscription_tags" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + body                    = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               + properties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   + tags = {}
TestDeploySubscriptionAliasManagementGroupValidAzApi:                 }
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         )
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + id                      = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + ignore_casing           = false
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + ignore_missing_property = true
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + name                    = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + output                  = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + parent_id               = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + resource_id             = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + type                    = "Microsoft.Resources/tags@2022-09-01"
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0] will be created
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + resource "time_sleep" "wait_for_subscription_before_subscription_operations" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + create_duration  = "30s"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + destroy_duration = "0s"
TestDeploySubscriptionAliasManagementGroupValidAzApi:       + id               = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Plan: 6 to add, 0 to change, 0 to destroy.
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Changes to Outputs:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   + subscription_id = (known after apply)
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: ─────────────────────────────────────────────────────────────────────────────
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Saved the plan to: tfplan
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: To perform exactly these actions, run the following command to apply:
TestDeploySubscriptionAliasManagementGroupValidAzApi:     terraform apply "tfplan"
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [show -no-color -json tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi: {"format_version":"1.1","terraform_version":"1.4.6","variables":{"subscription_alias_enabled":{"value":"true"},"subscription_alias_name":{"value":"testdeploy-e7e4ecfb"},"subscription_billing_scope":{"value":"/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231"},"subscription_display_name":{"value":"testdeploy-e7e4ecfb"},"subscription_management_group_association_enabled":{"value":"true"},"subscription_management_group_id":{"value":"testdeploy-e7e4ecfb"},"subscription_use_azapi":{"value":"true"},"subscription_workload":{"value":"DevTest"}},"planned_values":{"outputs":{"subscription_id":{"sensitive":false}},"root_module":{"resources":[{"address":"azapi_resource.mg","mode":"managed","type":"azapi_resource","name":"mg","provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"body":"{}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"name":"testdeploy-e7e4ecfb","parent_id":"/","removing_special_chars":false,"response_export_values":null,"schema_validation_enabled":true,"timeouts":null,"type":"Microsoft.Management/managementGroups@2021-04-01"},"sensitive_values":{"identity":[],"tags":{}}}],"child_modules":[{"resources":[{"address":"module.subscription_test.azapi_resource.subscription[0]","mode":"managed","type":"azapi_resource","name":"subscription","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"body":"{\"properties\":{\"additionalProperties\":{\"managementGroupId\":\"/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb\",\"tags\":{}},\"billingScope\":\"/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231\",\"displayName\":\"testdeploy-e7e4ecfb\",\"workload\":\"DevTest\"}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"name":"testdeploy-e7e4ecfb","parent_id":"/","removing_special_chars":false,"response_export_values":["properties.subscriptionId"],"schema_validation_enabled":true,"timeouts":null,"type":"Microsoft.Subscription/aliases@2021-10-01"},"sensitive_values":{"identity":[],"response_export_values":[false],"tags":{}}},{"address":"module.subscription_test.azapi_resource_action.subscription_association[0]","mode":"managed","type":"azapi_resource_action","name":"subscription_association","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"action":null,"body":null,"locks":null,"method":"PUT","response_export_values":null,"timeouts":null,"type":"Microsoft.Management/managementGroups/subscriptions@2021-04-01"},"sensitive_values":{}},{"address":"module.subscription_test.azapi_resource_action.subscription_rename[0]","mode":"managed","type":"azapi_resource_action","name":"subscription_rename","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"action":"providers/Microsoft.Subscription/rename","body":"{\"subscriptionName\":\"testdeploy-e7e4ecfb\"}","locks":null,"method":"POST","response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/subscriptions@2021-10-01"},"sensitive_values":{}},{"address":"module.subscription_test.azapi_update_resource.subscription_tags[0]","mode":"managed","type":"azapi_update_resource","name":"subscription_tags","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"body":"{\"properties\":{\"tags\":{}}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/tags@2022-09-01"},"sensitive_values":{}},{"address":"module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]","mode":"managed","type":"time_sleep","name":"wait_for_subscription_before_subscription_operations","index":0,"provider_name":"registry.terraform.io/hashicorp/time","schema_version":0,"values":{"create_duration":"30s","destroy_duration":"0s","triggers":null},"sensitive_values":{}}],"address":"module.subscription_test"}]}},"resource_changes":[{"address":"azapi_resource.mg","mode":"managed","type":"azapi_resource","name":"mg","provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"body":"{}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"name":"testdeploy-e7e4ecfb","parent_id":"/","removing_special_chars":false,"response_export_values":null,"schema_validation_enabled":true,"timeouts":null,"type":"Microsoft.Management/managementGroups@2021-04-01"},"after_unknown":{"id":true,"identity":true,"location":true,"output":true,"tags":true},"before_sensitive":false,"after_sensitive":{"identity":[],"tags":{}}}},{"address":"module.subscription_test.azapi_resource.subscription[0]","module_address":"module.subscription_test","mode":"managed","type":"azapi_resource","name":"subscription","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"body":"{\"properties\":{\"additionalProperties\":{\"managementGroupId\":\"/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb\",\"tags\":{}},\"billingScope\":\"/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231\",\"displayName\":\"testdeploy-e7e4ecfb\",\"workload\":\"DevTest\"}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"name":"testdeploy-e7e4ecfb","parent_id":"/","removing_special_chars":false,"response_export_values":["properties.subscriptionId"],"schema_validation_enabled":true,"timeouts":null,"type":"Microsoft.Subscription/aliases@2021-10-01"},"after_unknown":{"id":true,"identity":true,"location":true,"output":true,"response_export_values":[false],"tags":true},"before_sensitive":false,"after_sensitive":{"identity":[],"response_export_values":[false],"tags":{}}}},{"address":"module.subscription_test.azapi_resource_action.subscription_association[0]","module_address":"module.subscription_test","mode":"managed","type":"azapi_resource_action","name":"subscription_association","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"action":null,"body":null,"locks":null,"method":"PUT","response_export_values":null,"timeouts":null,"type":"Microsoft.Management/managementGroups/subscriptions@2021-04-01"},"after_unknown":{"id":true,"output":true,"resource_id":true},"before_sensitive":false,"after_sensitive":{}}},{"address":"module.subscription_test.azapi_resource_action.subscription_rename[0]","module_address":"module.subscription_test","mode":"managed","type":"azapi_resource_action","name":"subscription_rename","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"action":"providers/Microsoft.Subscription/rename","body":"{\"subscriptionName\":\"testdeploy-e7e4ecfb\"}","locks":null,"method":"POST","response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/subscriptions@2021-10-01"},"after_unknown":{"id":true,"output":true,"resource_id":true},"before_sensitive":false,"after_sensitive":{}}},{"address":"module.subscription_test.azapi_update_resource.subscription_tags[0]","module_address":"module.subscription_test","mode":"managed","type":"azapi_update_resource","name":"subscription_tags","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"body":"{\"properties\":{\"tags\":{}}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/tags@2022-09-01"},"after_unknown":{"id":true,"name":true,"output":true,"parent_id":true,"resource_id":true},"before_sensitive":false,"after_sensitive":{}}},{"address":"module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]","module_address":"module.subscription_test","mode":"managed","type":"time_sleep","name":"wait_for_subscription_before_subscription_operations","index":0,"provider_name":"registry.terraform.io/hashicorp/time","change":{"actions":["create"],"before":null,"after":{"create_duration":"30s","destroy_duration":"0s","triggers":null},"after_unknown":{"id":true},"before_sensitive":false,"after_sensitive":{}}}],"output_changes":{"subscription_id":{"actions":["create"],"before":null,"after_unknown":true,"before_sensitive":false,"after_sensitive":false}},"configuration":{"provider_config":{"azapi":{"name":"azapi","full_name":"registry.terraform.io/azure/azapi","version_constraint":"\u003e= 1.4.0"},"azurerm":{"name":"azurerm","full_name":"registry.terraform.io/hashicorp/azurerm","version_constraint":"\u003e= 3.7.0","expressions":{"features":[{}]}},"module.subscription_test:time":{"name":"time","full_name":"registry.terraform.io/hashicorp/time","version_constraint":"\u003e= 0.9.1","module_address":"module.subscription_test"}},"root_module":{"outputs":{"subscription_id":{"expression":{"references":["module.subscription_test.subscription_id","module.subscription_test"]}}},"resources":[{"address":"azapi_resource.mg","mode":"managed","type":"azapi_resource","name":"mg","provider_config_key":"azapi","expressions":{"name":{"references":["var.subscription_management_group_id"]},"parent_id":{"constant_value":"/"},"type":{"constant_value":"Microsoft.Management/managementGroups@2021-04-01"}},"schema_version":0}],"module_calls":{"subscription_test":{"source":"../../","expressions":{"subscription_alias_enabled":{"references":["var.subscription_alias_enabled"]},"subscription_alias_name":{"references":["var.subscription_alias_name"]},"subscription_billing_scope":{"references":["var.subscription_billing_scope"]},"subscription_display_name":{"references":["var.subscription_display_name"]},"subscription_management_group_association_enabled":{"references":["var.subscription_management_group_association_enabled"]},"subscription_management_group_id":{"references":["azapi_resource.mg.name","azapi_resource.mg"]},"subscription_use_azapi":{"references":["var.subscription_use_azapi"]},"subscription_workload":{"references":["var.subscription_workload"]}},"module":{"outputs":{"management_group_subscription_association_id":{"expression":{"references":["var.subscription_management_group_association_enabled","azurerm_management_group_subscription_association.this[0].id","azurerm_management_group_subscription_association.this[0]","azurerm_management_group_subscription_association.this"]},"description":"The management_group_subscription_association_id output is the ID of the management group subscription association.\nValue will be null if `var.subscription_management_group_association_enabled` is false.\n"},"subscription_id":{"expression":{"references":["local.subscription_id"]},"description":"The subscription_id is the id of the newly created subscription, or that of the supplied var.subscription_id.\nValue will be null if `var.subscription_id` is blank and `var.subscription_alias_enabled` is false.\n"},"subscription_resource_id":{"expression":{"references":["local.subscription_id","local.subscription_id"]},"description":"The subscription_resource_id output is the Azure resource id for the newly created subscription.\nValue will be null if `var.subscription_id` is blank and `var.subscription_alias_enabled` is false.\n"}},"resources":[{"address":"azapi_resource.subscription","mode":"managed","type":"azapi_resource","name":"subscription","provider_config_key":"azapi","expressions":{"body":{"references":["var.subscription_display_name","var.subscription_workload","var.subscription_billing_scope","var.subscription_management_group_association_enabled","var.subscription_management_group_id","var.subscription_tags"]},"name":{"references":["var.subscription_alias_name"]},"parent_id":{"constant_value":"/"},"response_export_values":{"constant_value":["properties.subscriptionId"]},"type":{"constant_value":"Microsoft.Subscription/aliases@2021-10-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi"]}},{"address":"azapi_resource_action.subscription_association","mode":"managed","type":"azapi_resource_action","name":"subscription_association","provider_config_key":"azapi","expressions":{"method":{"constant_value":"PUT"},"resource_id":{"references":["var.subscription_management_group_id","azapi_resource.subscription[0].output","azapi_resource.subscription[0]","azapi_resource.subscription"]},"type":{"constant_value":"Microsoft.Management/managementGroups/subscriptions@2021-04-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_management_group_association_enabled","var.subscription_use_azapi"]},"depends_on":["time_sleep.wait_for_subscription_before_subscription_operations"]},{"address":"azapi_resource_action.subscription_rename","mode":"managed","type":"azapi_resource_action","name":"subscription_rename","provider_config_key":"azapi","expressions":{"action":{"constant_value":"providers/Microsoft.Subscription/rename"},"body":{"references":["var.subscription_display_name"]},"method":{"constant_value":"POST"},"resource_id":{"references":["local.subscription_id"]},"type":{"constant_value":"Microsoft.Resources/subscriptions@2021-10-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi","var.subscription_id","var.subscription_update_existing"]},"depends_on":["time_sleep.wait_for_subscription_before_subscription_operations"]},{"address":"azapi_update_resource.subscription_tags","mode":"managed","type":"azapi_update_resource","name":"subscription_tags","provider_config_key":"azapi","expressions":{"body":{"references":["var.subscription_tags"]},"resource_id":{"references":["local.subscription_id"]},"type":{"constant_value":"Microsoft.Resources/tags@2022-09-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi","var.subscription_id","var.subscription_update_existing"]},"depends_on":["time_sleep.wait_for_subscription_before_subscription_operations"]},{"address":"azurerm_management_group_subscription_association.this","mode":"managed","type":"azurerm_management_group_subscription_association","name":"this","provider_config_key":"azurerm","expressions":{"management_group_id":{"references":["var.subscription_management_group_id"]},"subscription_id":{"references":["local.subscription_id"]}},"schema_version":0,"count_expression":{"references":["var.subscription_management_group_association_enabled","var.subscription_use_azapi"]}},{"address":"azurerm_subscription.this","mode":"managed","type":"azurerm_subscription","name":"this","provider_config_key":"azurerm","expressions":{"alias":{"references":["var.subscription_alias_name"]},"billing_scope_id":{"references":["var.subscription_billing_scope"]},"subscription_name":{"references":["var.subscription_display_name"]},"tags":{"references":["var.subscription_tags"]},"workload":{"references":["var.subscription_workload"]}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi"]}},{"address":"time_sleep.wait_for_subscription_before_subscription_operations","mode":"managed","type":"time_sleep","name":"wait_for_subscription_before_subscription_operations","provider_config_key":"module.subscription_test:time","expressions":{"create_duration":{"references":["var.wait_for_subscription_before_subscription_operations.create","var.wait_for_subscription_before_subscription_operations"]},"destroy_duration":{"references":["var.wait_for_subscription_before_subscription_operations.destroy","var.wait_for_subscription_before_subscription_operations"]}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi"]},"depends_on":["azapi_resource.subscription"]}],"variables":{"subscription_alias_enabled":{"default":false,"description":"Whether to create a new subscription using the subscription alias resource.\n\nIf enabled, the following must also be supplied:\n\n- `subscription_alias_name`\n- `subscription_display_name`\n- `subscription_billing_scope`\n- `subscription_workload`\n\nOptionally, supply the following to enable the placement of the subscription into a management group:\n\n- `subscription_management_group_id`\n- `subscription_management_group_association_enabled`\n\nIf disabled, supply the `subscription_id` variable to use an existing subscription instead.\n\n\u003e **Note**: When the subscription is destroyed, this module will try to remove the NetworkWatcherRG resource group using `az cli`.\n\u003e This requires the `az cli` tool be installed and authenticated.\n\u003e If the command fails for any reason, the provider will attempt to cancel the subscription anyway.\n"},"subscription_alias_name":{"default":"","description":"The name of the subscription alias.\n\nThe string must be comprised of a-z, A-Z, 0-9, - and _.\nThe maximum length is 63 characters.\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"subscription_billing_scope":{"default":"","description":"The billing scope for the new subscription alias.\n\nA valid billing scope starts with `/providers/Microsoft.Billing/billingAccounts/` and is case sensitive.\n\nE.g.\n\n- For CustomerLed and FieldLed, e.g. MCA - `/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}`\n- For PartnerLed, e.g. MPA - `/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/customers/{customerName}`\n- For Legacy EA - `/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/enrollmentAccounts/{enrollmentAccountName}`\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"subscription_display_name":{"default":"","description":"The display name of the subscription alias.\n\nThe string must be comprised of a-z, A-Z, 0-9, -, _ and space.\nThe maximum length is 63 characters.\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"subscription_id":{"default":""},"subscription_management_group_association_enabled":{"default":false,"description":"Whether to create the `azurerm_management_group_subscription_association` resource.\n\nIf enabled, the `subscription_management_group_id` must also be supplied.\n"},"subscription_management_group_id":{"default":"","description":"The destination management group ID for the new subscription.\n\n**Note:** Do not supply the display name.\nThe management group ID forms part of the Azure resource ID. E.g.,\n`/providers/Microsoft.Management/managementGroups/{managementGroupId}`.\n"},"subscription_tags":{"default":{},"description":"A map of tags to assign to the newly created subscription.\nOnly valid when `subsciption_alias_enabled` is set to `true`.\n\nExample value:\n\n```terraform\nsubscription_tags = {\n  mytag  = \"myvalue\"\n  mytag2 = \"myvalue2\"\n}\n```\n"},"subscription_update_existing":{"default":false,"description":"Whether to update an existing subscription with the supplied tags and display name.\nIf enabled, the following must also be supplied:\n- `subscription_id`\n"},"subscription_use_azapi":{"default":false,"description":"Whether to use the azapi_resource resource to create the subscription alias. This includes the subscription alias in the management group.\n"},"subscription_workload":{"default":"","description":"The billing scope for the new subscription alias.\n\nThe workload type can be either `Production` or `DevTest` and is case sensitive.\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"wait_for_subscription_before_subscription_operations":{"default":{"create":"30s","destroy":"0s"},"description":"The duration to wait after vending a subscription before performing subscription operations.\n"}}}}},"variables":{"subscription_alias_enabled":{},"subscription_alias_name":{},"subscription_billing_scope":{},"subscription_display_name":{},"subscription_management_group_association_enabled":{},"subscription_management_group_id":{},"subscription_use_azapi":{},"subscription_workload":{}}}},"relevant_attributes":[{"resource":"azapi_resource.mg","attribute":["name"]},{"resource":"module.subscription_test.azurerm_subscription.this[0]","attribute":["subscription_id"]},{"resource":"module.subscription_test.azapi_resource.subscription[0]","attribute":["output"]}]}
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [apply -input=false -auto-approve -no-color -lock=true tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Creating...
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Still creating... [10s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Still creating... [20s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Creation complete after 24s [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Creating...
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Still creating... [10s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Still creating... [20s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Still creating... [30s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Creation complete after 30s [id=/providers/Microsoft.Subscription/aliases/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Creating...
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Still creating... [10s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Still creating... [20s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Still creating... [30s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Creation complete after 30s [id=2023-12-06T16:47:17Z]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_association[0]: Creating...
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_rename[0]: Creating...
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_update_resource.subscription_tags[0]: Creating...
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_association[0]: Creation complete after 1s [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_update_resource.subscription_tags[0]: Creation complete after 2s [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_rename[0]: Creation complete after 3s [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Outputs:
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: subscription_id = "b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3"
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [plan -input=false -detailed-exitcode -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_management_group_id=testdeploy-e7e4ecfb -var subscription_management_group_association_enabled=true -var subscription_alias_name=testdeploy-e7e4ecfb -var subscription_display_name=testdeploy-e7e4ecfb -no-color -lock=true -out=tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [plan -input=false -detailed-exitcode -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_management_group_id=testdeploy-e7e4ecfb -var subscription_management_group_association_enabled=true -var subscription_alias_name=testdeploy-e7e4ecfb -var subscription_display_name=testdeploy-e7e4ecfb -no-color -lock=true -out=tfplan]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Refreshing state... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Refreshing state... [id=/providers/Microsoft.Subscription/aliases/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Refreshing state... [id=2023-12-06T16:47:17Z]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_association[0]: Refreshing state... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_update_resource.subscription_tags[0]: Refreshing state... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_rename[0]: Refreshing state... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: No changes. Your infrastructure matches the configuration.
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform has compared your real infrastructure against your configuration
TestDeploySubscriptionAliasManagementGroupValidAzApi: and found no differences, so no changes are needed.
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [output -no-color -json subscription_id]
TestDeploySubscriptionAliasManagementGroupValidAzApi: "b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3"
TestDeploySubscriptionAliasManagementGroupValidAzApi: terraform [destroy -auto-approve -input=false -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_management_group_id=testdeploy-e7e4ecfb -var subscription_management_group_association_enabled=true -var subscription_alias_name=testdeploy-e7e4ecfb -var subscription_display_name=testdeploy-e7e4ecfb -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -no-color -lock=true]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Refreshing state... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Refreshing state... [id=/providers/Microsoft.Subscription/aliases/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Refreshing state... [id=2023-12-06T16:47:17Z]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_association[0]: Refreshing state... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_update_resource.subscription_tags[0]: Refreshing state... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_rename[0]: Refreshing state... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform used the selected providers to generate the following execution
TestDeploySubscriptionAliasManagementGroupValidAzApi: plan. Resource actions are indicated with the following symbols:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - destroy
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Terraform will perform the following actions:
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # azapi_resource.mg will be destroyed
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - resource "azapi_resource" "mg" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - body                      = jsonencode({})
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - id                        = "/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - ignore_casing             = false -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - ignore_missing_property   = true -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - name                      = "testdeploy-e7e4ecfb" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - output                    = jsonencode({})
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - parent_id                 = "/" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - removing_special_chars    = false -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - schema_validation_enabled = true -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - tags                      = {} -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - type                      = "Microsoft.Management/managementGroups@2021-04-01" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_resource.subscription[0] will be destroyed
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - resource "azapi_resource" "subscription" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - body                      = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               - properties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   - additionalProperties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                       - managementGroupId = "/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                       - tags              = {}
TestDeploySubscriptionAliasManagementGroupValidAzApi:                     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   - billingScope         = "/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   - displayName          = "testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   - workload             = "DevTest"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                 }
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         ) -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - id                        = "/providers/Microsoft.Subscription/aliases/testdeploy-e7e4ecfb" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - ignore_casing             = false -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - ignore_missing_property   = true -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - name                      = "testdeploy-e7e4ecfb" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - output                    = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               - properties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   - subscriptionId = "b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3"
TestDeploySubscriptionAliasManagementGroupValidAzApi:                 }
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         ) -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - parent_id                 = "/" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - removing_special_chars    = false -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - response_export_values    = [
TestDeploySubscriptionAliasManagementGroupValidAzApi:           - "properties.subscriptionId",
TestDeploySubscriptionAliasManagementGroupValidAzApi:         ] -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - schema_validation_enabled = true -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - tags                      = {} -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - type                      = "Microsoft.Subscription/aliases@2021-10-01" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_resource_action.subscription_association[0] will be destroyed
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - resource "azapi_resource_action" "subscription_association" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - id          = "/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - method      = "PUT" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - output      = jsonencode({})
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - resource_id = "/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - type        = "Microsoft.Management/managementGroups/subscriptions@2021-04-01" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_resource_action.subscription_rename[0] will be destroyed
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - resource "azapi_resource_action" "subscription_rename" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - action      = "providers/Microsoft.Subscription/rename" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - body        = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               - subscriptionName = "testdeploy-e7e4ecfb"
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         ) -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - id          = "/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Subscription/rename" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - method      = "POST" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - output      = jsonencode({})
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - resource_id = "/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - type        = "Microsoft.Resources/subscriptions@2021-10-01" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.azapi_update_resource.subscription_tags[0] will be destroyed
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - resource "azapi_update_resource" "subscription_tags" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - body                    = jsonencode(
TestDeploySubscriptionAliasManagementGroupValidAzApi:             {
TestDeploySubscriptionAliasManagementGroupValidAzApi:               - properties = {
TestDeploySubscriptionAliasManagementGroupValidAzApi:                   - tags = {}
TestDeploySubscriptionAliasManagementGroupValidAzApi:                 }
TestDeploySubscriptionAliasManagementGroupValidAzApi:             }
TestDeploySubscriptionAliasManagementGroupValidAzApi:         ) -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - id                      = "/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - ignore_casing           = false -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - ignore_missing_property = true -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - name                    = "default" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - output                  = jsonencode({})
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - parent_id               = "/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - resource_id             = "/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - type                    = "Microsoft.Resources/tags@2022-09-01" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   # module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0] will be destroyed
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - resource "time_sleep" "wait_for_subscription_before_subscription_operations" {
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - create_duration  = "30s" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - destroy_duration = "0s" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:       - id               = "2023-12-06T16:47:17Z" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi:     }
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Plan: 0 to add, 0 to change, 6 to destroy.
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Changes to Outputs:
TestDeploySubscriptionAliasManagementGroupValidAzApi:   - subscription_id = "b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3" -> null
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_rename[0]: Destroying... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_update_resource.subscription_tags[0]: Destroying... [id=/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_association[0]: Destroying... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb/subscriptions/b39af4b2-5ecb-4ca4-a82c-fc8a6f7a31e3]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_rename[0]: Destruction complete after 0s
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource_action.subscription_association[0]: Destruction complete after 0s
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_update_resource.subscription_tags[0]: Destruction complete after 0s
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Destroying... [id=2023-12-06T16:47:17Z]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.time_sleep.wait_for_subscription_before_subscription_operations[0]: Destruction complete after 0s
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Destroying... [id=/providers/Microsoft.Subscription/aliases/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: module.subscription_test.azapi_resource.subscription[0]: Destruction complete after 2s
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Destroying... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Still destroying... [id=/providers/Microsoft.Management/managementGroups/testdeploy-e7e4ecfb, 10s elapsed]
TestDeploySubscriptionAliasManagementGroupValidAzApi: azapi_resource.mg: Destruction complete after 12s
TestDeploySubscriptionAliasManagementGroupValidAzApi:
TestDeploySubscriptionAliasManagementGroupValidAzApi: Destroy complete! Resources: 6 destroyed.
--- PASS: TestDeploySubscriptionAliasManagementGroupValidAzApi (185.71s)
```

```
=== RUN   TestDeploySubscriptionAliasValidAzApi
=== PAUSE TestDeploySubscriptionAliasValidAzApi
=== CONT  TestDeploySubscriptionAliasValidAzApi
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:53:34Z test_structure.go:130: Copied terraform folder ../../modules/subscription to /tmp/TestDeploySubscriptionAliasValidAzApi4078887112/subscription
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:53:34Z retry.go:91: terraform [init -upgrade=false -no-color]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:54:00Z retry.go:91: terraform [plan -input=false -lock=false -var subscription_alias_enabled=true -var subscription_alias_name=testdeploy-a29a28fe -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -no-color -lock=true -out=tfplan]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:54:14Z logger.go:51: logging sample: [                    }]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:54:14Z logger.go:51: logging sample: [      + name                    = (known after apply)]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:54:14Z retry.go:91: terraform [show -no-color -json tfplan]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:54:15Z retry.go:91: terraform [apply -input=false -auto-approve -no-color -lock=true tfplan]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:55:12Z logger.go:51: logging sample: [terraform [plan -input=false -detailed-exitcode -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_alias_name=testdeploy-a29a28fe -no-color -lock=true -out=tfplan]]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:55:24Z retry.go:91: terraform [output -no-color -json]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:55:25Z retry.go:91: terraform [destroy -auto-approve -input=false -var subscription_alias_name=testdeploy-a29a28fe -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -no-color -lock=true]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:55:38Z logger.go:51: logging sample: [      - id                        = "/providers/Microsoft.Subscription/aliases/testdeploy-a29a28fe" -> null]
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:55:38Z logger.go:51: logging sample: [      - parent_id               = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72" -> null]
    subscription.go:20: cancelling subscription 6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72
    subscription.go:40: removing 0 resource groups for subscription 6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72
    subscription.go:52: removed 0 resource groups for subscription 6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72
TestDeploySubscriptionAliasValidAzApi 2023-12-06T16:55:44Z retry.go:91: cancel subscription
    subscription.go:77: cancelled subscription 6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72
TestDeploySubscriptionAliasValidAzApi: terraform [init -upgrade=false -no-color]
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Initializing the backend...
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Initializing provider plugins...
TestDeploySubscriptionAliasValidAzApi: - Finding hashicorp/azurerm versions matching ">= 3.7.0"...
TestDeploySubscriptionAliasValidAzApi: - Finding azure/azapi versions matching ">= 1.4.0"...
TestDeploySubscriptionAliasValidAzApi: - Finding latest version of hashicorp/time...
TestDeploySubscriptionAliasValidAzApi: - Installing hashicorp/azurerm v3.83.0...
TestDeploySubscriptionAliasValidAzApi: - Installed hashicorp/azurerm v3.83.0 (signed by HashiCorp)
TestDeploySubscriptionAliasValidAzApi: - Installing azure/azapi v1.10.0...
TestDeploySubscriptionAliasValidAzApi: - Installed azure/azapi v1.10.0 (signed by a HashiCorp partner, key ID 6F0B91BDE98478CF)
TestDeploySubscriptionAliasValidAzApi: - Installing hashicorp/time v0.10.0...
TestDeploySubscriptionAliasValidAzApi: - Installed hashicorp/time v0.10.0 (signed by HashiCorp)
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Partner and community providers are signed by their developers.
TestDeploySubscriptionAliasValidAzApi: If you'd like to know more about provider signing, you can read about it here:
TestDeploySubscriptionAliasValidAzApi: https://www.terraform.io/docs/cli/plugins/signing.html
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform has created a lock file .terraform.lock.hcl to record the provider
TestDeploySubscriptionAliasValidAzApi: selections it made above. Include this file in your version control repository
TestDeploySubscriptionAliasValidAzApi: so that Terraform can guarantee to make the same selections by default when
TestDeploySubscriptionAliasValidAzApi: you run "terraform init" in the future.
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform has been successfully initialized!
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: You may now begin working with Terraform. Try running "terraform plan" to see
TestDeploySubscriptionAliasValidAzApi: any changes that are required for your infrastructure. All Terraform commands
TestDeploySubscriptionAliasValidAzApi: should now work.
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: If you ever set or change modules or backend configuration for Terraform,
TestDeploySubscriptionAliasValidAzApi: rerun this command to reinitialize your working directory. If you forget, other
TestDeploySubscriptionAliasValidAzApi: commands will detect it and remind you to do so if necessary.
TestDeploySubscriptionAliasValidAzApi: terraform [plan -input=false -lock=false -var subscription_alias_enabled=true -var subscription_alias_name=testdeploy-a29a28fe -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -no-color -lock=true -out=tfplan]
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform used the selected providers to generate the following execution
TestDeploySubscriptionAliasValidAzApi: plan. Resource actions are indicated with the following symbols:
TestDeploySubscriptionAliasValidAzApi:   + create
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform will perform the following actions:
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # azapi_resource.subscription[0] will be created
TestDeploySubscriptionAliasValidAzApi:   + resource "azapi_resource" "subscription" {
TestDeploySubscriptionAliasValidAzApi:       + body                      = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               + properties = {
TestDeploySubscriptionAliasValidAzApi:                   + additionalProperties = {
TestDeploySubscriptionAliasValidAzApi:                       + managementGroupId = null
TestDeploySubscriptionAliasValidAzApi:                       + tags              = {}
TestDeploySubscriptionAliasValidAzApi:                     }
TestDeploySubscriptionAliasValidAzApi:                   + billingScope         = "/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231"
TestDeploySubscriptionAliasValidAzApi:                   + displayName          = "testdeploy-a29a28fe"
TestDeploySubscriptionAliasValidAzApi:                   + workload             = "DevTest"
TestDeploySubscriptionAliasValidAzApi:                 }
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         )
TestDeploySubscriptionAliasValidAzApi:       + id                        = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + ignore_casing             = false
TestDeploySubscriptionAliasValidAzApi:       + ignore_missing_property   = true
TestDeploySubscriptionAliasValidAzApi:       + location                  = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + name                      = "testdeploy-a29a28fe"
TestDeploySubscriptionAliasValidAzApi:       + output                    = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + parent_id                 = "/"
TestDeploySubscriptionAliasValidAzApi:       + removing_special_chars    = false
TestDeploySubscriptionAliasValidAzApi:       + response_export_values    = [
TestDeploySubscriptionAliasValidAzApi:           + "properties.subscriptionId",
TestDeploySubscriptionAliasValidAzApi:         ]
TestDeploySubscriptionAliasValidAzApi:       + schema_validation_enabled = true
TestDeploySubscriptionAliasValidAzApi:       + tags                      = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + type                      = "Microsoft.Subscription/aliases@2021-10-01"
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # azapi_resource_action.subscription_rename[0] will be created
TestDeploySubscriptionAliasValidAzApi:   + resource "azapi_resource_action" "subscription_rename" {
TestDeploySubscriptionAliasValidAzApi:       + action      = "providers/Microsoft.Subscription/rename"
TestDeploySubscriptionAliasValidAzApi:       + body        = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               + subscriptionName = "testdeploy-a29a28fe"
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         )
TestDeploySubscriptionAliasValidAzApi:       + id          = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + method      = "POST"
TestDeploySubscriptionAliasValidAzApi:       + output      = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + resource_id = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + type        = "Microsoft.Resources/subscriptions@2021-10-01"
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # azapi_update_resource.subscription_tags[0] will be created
TestDeploySubscriptionAliasValidAzApi:   + resource "azapi_update_resource" "subscription_tags" {
TestDeploySubscriptionAliasValidAzApi:       + body                    = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               + properties = {
TestDeploySubscriptionAliasValidAzApi:                   + tags = {}
TestDeploySubscriptionAliasValidAzApi:                 }
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         )
TestDeploySubscriptionAliasValidAzApi:       + id                      = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + ignore_casing           = false
TestDeploySubscriptionAliasValidAzApi:       + ignore_missing_property = true
TestDeploySubscriptionAliasValidAzApi:       + name                    = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + output                  = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + parent_id               = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + resource_id             = (known after apply)
TestDeploySubscriptionAliasValidAzApi:       + type                    = "Microsoft.Resources/tags@2022-09-01"
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # time_sleep.wait_for_subscription_before_subscription_operations[0] will be created
TestDeploySubscriptionAliasValidAzApi:   + resource "time_sleep" "wait_for_subscription_before_subscription_operations" {
TestDeploySubscriptionAliasValidAzApi:       + create_duration  = "30s"
TestDeploySubscriptionAliasValidAzApi:       + destroy_duration = "0s"
TestDeploySubscriptionAliasValidAzApi:       + id               = (known after apply)
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Plan: 4 to add, 0 to change, 0 to destroy.
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Changes to Outputs:
TestDeploySubscriptionAliasValidAzApi:   + subscription_id                              = (known after apply)
TestDeploySubscriptionAliasValidAzApi:   + subscription_resource_id                     = (known after apply)
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: ─────────────────────────────────────────────────────────────────────────────
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Saved the plan to: tfplan
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: To perform exactly these actions, run the following command to apply:
TestDeploySubscriptionAliasValidAzApi:     terraform apply "tfplan"
TestDeploySubscriptionAliasValidAzApi: terraform [show -no-color -json tfplan]
TestDeploySubscriptionAliasValidAzApi: {"format_version":"1.1","terraform_version":"1.4.6","variables":{"subscription_alias_enabled":{"value":"true"},"subscription_alias_name":{"value":"testdeploy-a29a28fe"},"subscription_billing_scope":{"value":"/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231"},"subscription_display_name":{"value":"testdeploy-a29a28fe"},"subscription_id":{"value":""},"subscription_management_group_association_enabled":{"value":false},"subscription_management_group_id":{"value":""},"subscription_tags":{"value":{}},"subscription_update_existing":{"value":false},"subscription_use_azapi":{"value":"true"},"subscription_workload":{"value":"DevTest"},"wait_for_subscription_before_subscription_operations":{"value":{"create":"30s","destroy":"0s"}}},"planned_values":{"outputs":{"management_group_subscription_association_id":{"sensitive":false,"type":"dynamic","value":null},"subscription_id":{"sensitive":false},"subscription_resource_id":{"sensitive":false}},"root_module":{"resources":[{"address":"azapi_resource.subscription[0]","mode":"managed","type":"azapi_resource","name":"subscription","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"body":"{\"properties\":{\"additionalProperties\":{\"managementGroupId\":null,\"tags\":{}},\"billingScope\":\"/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231\",\"displayName\":\"testdeploy-a29a28fe\",\"workload\":\"DevTest\"}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"name":"testdeploy-a29a28fe","parent_id":"/","removing_special_chars":false,"response_export_values":["properties.subscriptionId"],"schema_validation_enabled":true,"timeouts":null,"type":"Microsoft.Subscription/aliases@2021-10-01"},"sensitive_values":{"identity":[],"response_export_values":[false],"tags":{}}},{"address":"azapi_resource_action.subscription_rename[0]","mode":"managed","type":"azapi_resource_action","name":"subscription_rename","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"action":"providers/Microsoft.Subscription/rename","body":"{\"subscriptionName\":\"testdeploy-a29a28fe\"}","locks":null,"method":"POST","response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/subscriptions@2021-10-01"},"sensitive_values":{}},{"address":"azapi_update_resource.subscription_tags[0]","mode":"managed","type":"azapi_update_resource","name":"subscription_tags","index":0,"provider_name":"registry.terraform.io/azure/azapi","schema_version":0,"values":{"body":"{\"properties\":{\"tags\":{}}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/tags@2022-09-01"},"sensitive_values":{}},{"address":"time_sleep.wait_for_subscription_before_subscription_operations[0]","mode":"managed","type":"time_sleep","name":"wait_for_subscription_before_subscription_operations","index":0,"provider_name":"registry.terraform.io/hashicorp/time","schema_version":0,"values":{"create_duration":"30s","destroy_duration":"0s","triggers":null},"sensitive_values":{}}]}},"resource_changes":[{"address":"azapi_resource.subscription[0]","mode":"managed","type":"azapi_resource","name":"subscription","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"body":"{\"properties\":{\"additionalProperties\":{\"managementGroupId\":null,\"tags\":{}},\"billingScope\":\"/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231\",\"displayName\":\"testdeploy-a29a28fe\",\"workload\":\"DevTest\"}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"name":"testdeploy-a29a28fe","parent_id":"/","removing_special_chars":false,"response_export_values":["properties.subscriptionId"],"schema_validation_enabled":true,"timeouts":null,"type":"Microsoft.Subscription/aliases@2021-10-01"},"after_unknown":{"id":true,"identity":true,"location":true,"output":true,"response_export_values":[false],"tags":true},"before_sensitive":false,"after_sensitive":{"identity":[],"response_export_values":[false],"tags":{}}}},{"address":"azapi_resource_action.subscription_rename[0]","mode":"managed","type":"azapi_resource_action","name":"subscription_rename","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"action":"providers/Microsoft.Subscription/rename","body":"{\"subscriptionName\":\"testdeploy-a29a28fe\"}","locks":null,"method":"POST","response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/subscriptions@2021-10-01"},"after_unknown":{"id":true,"output":true,"resource_id":true},"before_sensitive":false,"after_sensitive":{}}},{"address":"azapi_update_resource.subscription_tags[0]","mode":"managed","type":"azapi_update_resource","name":"subscription_tags","index":0,"provider_name":"registry.terraform.io/azure/azapi","change":{"actions":["create"],"before":null,"after":{"body":"{\"properties\":{\"tags\":{}}}","ignore_body_changes":null,"ignore_casing":false,"ignore_missing_property":true,"locks":null,"response_export_values":null,"timeouts":null,"type":"Microsoft.Resources/tags@2022-09-01"},"after_unknown":{"id":true,"name":true,"output":true,"parent_id":true,"resource_id":true},"before_sensitive":false,"after_sensitive":{}}},{"address":"time_sleep.wait_for_subscription_before_subscription_operations[0]","mode":"managed","type":"time_sleep","name":"wait_for_subscription_before_subscription_operations","index":0,"provider_name":"registry.terraform.io/hashicorp/time","change":{"actions":["create"],"before":null,"after":{"create_duration":"30s","destroy_duration":"0s","triggers":null},"after_unknown":{"id":true},"before_sensitive":false,"after_sensitive":{}}}],"output_changes":{"management_group_subscription_association_id":{"actions":["no-op"],"before":null,"after":null,"after_unknown":false,"before_sensitive":false,"after_sensitive":false},"subscription_id":{"actions":["create"],"before":null,"after_unknown":true,"before_sensitive":false,"after_sensitive":false},"subscription_resource_id":{"actions":["create"],"before":null,"after_unknown":true,"before_sensitive":false,"after_sensitive":false}},"configuration":{"provider_config":{"azapi":{"name":"azapi","full_name":"registry.terraform.io/azure/azapi","version_constraint":"\u003e= 1.4.0"},"azurerm":{"name":"azurerm","full_name":"registry.terraform.io/hashicorp/azurerm","version_constraint":"\u003e= 3.7.0","expressions":{"features":[{}]}},"time":{"name":"time","full_name":"registry.terraform.io/hashicorp/time"}},"root_module":{"outputs":{"management_group_subscription_association_id":{"expression":{"references":["var.subscription_management_group_association_enabled","azurerm_management_group_subscription_association.this[0].id","azurerm_management_group_subscription_association.this[0]","azurerm_management_group_subscription_association.this"]},"description":"The management_group_subscription_association_id output is the ID of the management group subscription association.\nValue will be null if `var.subscription_management_group_association_enabled` is false.\n"},"subscription_id":{"expression":{"references":["local.subscription_id"]},"description":"The subscription_id is the id of the newly created subscription, or that of the supplied var.subscription_id.\nValue will be null if `var.subscription_id` is blank and `var.subscription_alias_enabled` is false.\n"},"subscription_resource_id":{"expression":{"references":["local.subscription_id","local.subscription_id"]},"description":"The subscription_resource_id output is the Azure resource id for the newly created subscription.\nValue will be null if `var.subscription_id` is blank and `var.subscription_alias_enabled` is false.\n"}},"resources":[{"address":"azapi_resource.subscription","mode":"managed","type":"azapi_resource","name":"subscription","provider_config_key":"azapi","expressions":{"body":{"references":["var.subscription_display_name","var.subscription_workload","var.subscription_billing_scope","var.subscription_management_group_association_enabled","var.subscription_management_group_id","var.subscription_tags"]},"name":{"references":["var.subscription_alias_name"]},"parent_id":{"constant_value":"/"},"response_export_values":{"constant_value":["properties.subscriptionId"]},"type":{"constant_value":"Microsoft.Subscription/aliases@2021-10-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi"]}},{"address":"azapi_resource_action.subscription_association","mode":"managed","type":"azapi_resource_action","name":"subscription_association","provider_config_key":"azapi","expressions":{"method":{"constant_value":"PUT"},"resource_id":{"references":["var.subscription_management_group_id","azapi_resource.subscription[0].output","azapi_resource.subscription[0]","azapi_resource.subscription"]},"type":{"constant_value":"Microsoft.Management/managementGroups/subscriptions@2021-04-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_management_group_association_enabled","var.subscription_use_azapi"]},"depends_on":["time_sleep.wait_for_subscription_before_subscription_operations"]},{"address":"azapi_resource_action.subscription_rename","mode":"managed","type":"azapi_resource_action","name":"subscription_rename","provider_config_key":"azapi","expressions":{"action":{"constant_value":"providers/Microsoft.Subscription/rename"},"body":{"references":["var.subscription_display_name"]},"method":{"constant_value":"POST"},"resource_id":{"references":["local.subscription_id"]},"type":{"constant_value":"Microsoft.Resources/subscriptions@2021-10-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi","var.subscription_id","var.subscription_update_existing"]},"depends_on":["time_sleep.wait_for_subscription_before_subscription_operations"]},{"address":"azapi_update_resource.subscription_tags","mode":"managed","type":"azapi_update_resource","name":"subscription_tags","provider_config_key":"azapi","expressions":{"body":{"references":["var.subscription_tags"]},"resource_id":{"references":["local.subscription_id"]},"type":{"constant_value":"Microsoft.Resources/tags@2022-09-01"}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi","var.subscription_id","var.subscription_update_existing"]},"depends_on":["time_sleep.wait_for_subscription_before_subscription_operations"]},{"address":"azurerm_management_group_subscription_association.this","mode":"managed","type":"azurerm_management_group_subscription_association","name":"this","provider_config_key":"azurerm","expressions":{"management_group_id":{"references":["var.subscription_management_group_id"]},"subscription_id":{"references":["local.subscription_id"]}},"schema_version":0,"count_expression":{"references":["var.subscription_management_group_association_enabled","var.subscription_use_azapi"]}},{"address":"azurerm_subscription.this","mode":"managed","type":"azurerm_subscription","name":"this","provider_config_key":"azurerm","expressions":{"alias":{"references":["var.subscription_alias_name"]},"billing_scope_id":{"references":["var.subscription_billing_scope"]},"subscription_name":{"references":["var.subscription_display_name"]},"tags":{"references":["var.subscription_tags"]},"workload":{"references":["var.subscription_workload"]}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi"]}},{"address":"time_sleep.wait_for_subscription_before_subscription_operations","mode":"managed","type":"time_sleep","name":"wait_for_subscription_before_subscription_operations","provider_config_key":"time","expressions":{"create_duration":{"references":["var.wait_for_subscription_before_subscription_operations.create","var.wait_for_subscription_before_subscription_operations"]},"destroy_duration":{"references":["var.wait_for_subscription_before_subscription_operations.destroy","var.wait_for_subscription_before_subscription_operations"]}},"schema_version":0,"count_expression":{"references":["var.subscription_alias_enabled","var.subscription_use_azapi"]},"depends_on":["azapi_resource.subscription"]}],"variables":{"subscription_alias_enabled":{"default":false,"description":"Whether to create a new subscription using the subscription alias resource.\n\nIf enabled, the following must also be supplied:\n\n- `subscription_alias_name`\n- `subscription_display_name`\n- `subscription_billing_scope`\n- `subscription_workload`\n\nOptionally, supply the following to enable the placement of the subscription into a management group:\n\n- `subscription_management_group_id`\n- `subscription_management_group_association_enabled`\n\nIf disabled, supply the `subscription_id` variable to use an existing subscription instead.\n\n\u003e **Note**: When the subscription is destroyed, this module will try to remove the NetworkWatcherRG resource group using `az cli`.\n\u003e This requires the `az cli` tool be installed and authenticated.\n\u003e If the command fails for any reason, the provider will attempt to cancel the subscription anyway.\n"},"subscription_alias_name":{"default":"","description":"The name of the subscription alias.\n\nThe string must be comprised of a-z, A-Z, 0-9, - and _.\nThe maximum length is 63 characters.\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"subscription_billing_scope":{"default":"","description":"The billing scope for the new subscription alias.\n\nA valid billing scope starts with `/providers/Microsoft.Billing/billingAccounts/` and is case sensitive.\n\nE.g.\n\n- For CustomerLed and FieldLed, e.g. MCA - `/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}`\n- For PartnerLed, e.g. MPA - `/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/customers/{customerName}`\n- For Legacy EA - `/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/enrollmentAccounts/{enrollmentAccountName}`\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"subscription_display_name":{"default":"","description":"The display name of the subscription alias.\n\nThe string must be comprised of a-z, A-Z, 0-9, -, _ and space.\nThe maximum length is 63 characters.\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"subscription_id":{"default":""},"subscription_management_group_association_enabled":{"default":false,"description":"Whether to create the `azurerm_management_group_subscription_association` resource.\n\nIf enabled, the `subscription_management_group_id` must also be supplied.\n"},"subscription_management_group_id":{"default":"","description":"The destination management group ID for the new subscription.\n\n**Note:** Do not supply the display name.\nThe management group ID forms part of the Azure resource ID. E.g.,\n`/providers/Microsoft.Management/managementGroups/{managementGroupId}`.\n"},"subscription_tags":{"default":{},"description":"A map of tags to assign to the newly created subscription.\nOnly valid when `subsciption_alias_enabled` is set to `true`.\n\nExample value:\n\n```terraform\nsubscription_tags = {\n  mytag  = \"myvalue\"\n  mytag2 = \"myvalue2\"\n}\n```\n"},"subscription_update_existing":{"default":false,"description":"Whether to update an existing subscription with the supplied tags and display name.\nIf enabled, the following must also be supplied:\n- `subscription_id`\n"},"subscription_use_azapi":{"default":false,"description":"Whether to use the azapi_resource resource to create the subscription alias. This includes the subscription alias in the management group.\n"},"subscription_workload":{"default":"","description":"The billing scope for the new subscription alias.\n\nThe workload type can be either `Production` or `DevTest` and is case sensitive.\n\nYou may also supply an empty string if you do not want to create a new subscription alias.\nIn this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.\n"},"wait_for_subscription_before_subscription_operations":{"default":{"create":"30s","destroy":"0s"},"description":"The duration to wait after vending a subscription before performing subscription operations.\n"}}}},"relevant_attributes":[{"resource":"azapi_resource.subscription[0]","attribute":["output"]},{"resource":"azurerm_subscription.this[0]","attribute":["subscription_id"]}]}       
TestDeploySubscriptionAliasValidAzApi: terraform [apply -input=false -auto-approve -no-color -lock=true tfplan]
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Creating...
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Still creating... [10s elapsed]
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Still creating... [20s elapsed]
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Creation complete after 21s [id=/providers/Microsoft.Subscription/aliases/testdeploy-a29a28fe]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Creating...
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Still creating... [10s elapsed]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Still creating... [20s elapsed]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Still creating... [30s elapsed]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Creation complete after 30s [id=2023-12-06T16:55:09Z]
TestDeploySubscriptionAliasValidAzApi: azapi_resource_action.subscription_rename[0]: Creating...
TestDeploySubscriptionAliasValidAzApi: azapi_update_resource.subscription_tags[0]: Creating...
TestDeploySubscriptionAliasValidAzApi: azapi_update_resource.subscription_tags[0]: Creation complete after 3s [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasValidAzApi: azapi_resource_action.subscription_rename[0]: Creation complete after 3s [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Outputs:
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: subscription_id = "6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72"
TestDeploySubscriptionAliasValidAzApi: subscription_resource_id = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72"
TestDeploySubscriptionAliasValidAzApi: terraform [plan -input=false -detailed-exitcode -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_alias_name=testdeploy-a29a28fe -no-color -lock=true -out=tfplan]    
TestDeploySubscriptionAliasValidAzApi: terraform [plan -input=false -detailed-exitcode -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -var subscription_alias_name=testdeploy-a29a28fe -no-color -lock=true -out=tfplan]    
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Refreshing state... [id=/providers/Microsoft.Subscription/aliases/testdeploy-a29a28fe]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Refreshing state... [id=2023-12-06T16:55:09Z]
TestDeploySubscriptionAliasValidAzApi: azapi_update_resource.subscription_tags[0]: Refreshing state... [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasValidAzApi: azapi_resource_action.subscription_rename[0]: Refreshing state... [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: No changes. Your infrastructure matches the configuration.
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform has compared your real infrastructure against your configuration
TestDeploySubscriptionAliasValidAzApi: and found no differences, so no changes are needed.
TestDeploySubscriptionAliasValidAzApi: terraform [output -no-color -json]
TestDeploySubscriptionAliasValidAzApi: {
TestDeploySubscriptionAliasValidAzApi:   "subscription_id": {
TestDeploySubscriptionAliasValidAzApi:     "sensitive": false,
TestDeploySubscriptionAliasValidAzApi:     "type": "string",
TestDeploySubscriptionAliasValidAzApi:     "value": "6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72"
TestDeploySubscriptionAliasValidAzApi:   },
TestDeploySubscriptionAliasValidAzApi:   "subscription_resource_id": {
TestDeploySubscriptionAliasValidAzApi:     "sensitive": false,
TestDeploySubscriptionAliasValidAzApi:     "type": "string",
TestDeploySubscriptionAliasValidAzApi:     "value": "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72"
TestDeploySubscriptionAliasValidAzApi:   }
TestDeploySubscriptionAliasValidAzApi: }
TestDeploySubscriptionAliasValidAzApi: terraform [destroy -auto-approve -input=false -var subscription_alias_name=testdeploy-a29a28fe -var subscription_display_name=testdeploy-a29a28fe -var subscription_billing_scope=/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231 -var subscription_use_azapi=true -var subscription_workload=DevTest -var subscription_alias_enabled=true -no-color -lock=true]
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Refreshing state... [id=/providers/Microsoft.Subscription/aliases/testdeploy-a29a28fe]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Refreshing state... [id=2023-12-06T16:55:09Z]
TestDeploySubscriptionAliasValidAzApi: azapi_resource_action.subscription_rename[0]: Refreshing state... [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasValidAzApi: azapi_update_resource.subscription_tags[0]: Refreshing state... [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform used the selected providers to generate the following execution
TestDeploySubscriptionAliasValidAzApi: plan. Resource actions are indicated with the following symbols:
TestDeploySubscriptionAliasValidAzApi:   - destroy
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Terraform will perform the following actions:
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # azapi_resource.subscription[0] will be destroyed
TestDeploySubscriptionAliasValidAzApi:   - resource "azapi_resource" "subscription" {
TestDeploySubscriptionAliasValidAzApi:       - body                      = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               - properties = {
TestDeploySubscriptionAliasValidAzApi:                   - additionalProperties = {
TestDeploySubscriptionAliasValidAzApi:                       - managementGroupId = null
TestDeploySubscriptionAliasValidAzApi:                       - tags              = {}
TestDeploySubscriptionAliasValidAzApi:                     }
TestDeploySubscriptionAliasValidAzApi:                   - billingScope         = "/providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/352231"
TestDeploySubscriptionAliasValidAzApi:                   - displayName          = "testdeploy-a29a28fe"
TestDeploySubscriptionAliasValidAzApi:                   - workload             = "DevTest"
TestDeploySubscriptionAliasValidAzApi:                 }
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         ) -> null
TestDeploySubscriptionAliasValidAzApi:       - id                        = "/providers/Microsoft.Subscription/aliases/testdeploy-a29a28fe" -> null
TestDeploySubscriptionAliasValidAzApi:       - ignore_casing             = false -> null
TestDeploySubscriptionAliasValidAzApi:       - ignore_missing_property   = true -> null
TestDeploySubscriptionAliasValidAzApi:       - name                      = "testdeploy-a29a28fe" -> null
TestDeploySubscriptionAliasValidAzApi:       - output                    = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               - properties = {
TestDeploySubscriptionAliasValidAzApi:                   - subscriptionId = "6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72"
TestDeploySubscriptionAliasValidAzApi:                 }
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         ) -> null
TestDeploySubscriptionAliasValidAzApi:       - parent_id                 = "/" -> null
TestDeploySubscriptionAliasValidAzApi:       - removing_special_chars    = false -> null
TestDeploySubscriptionAliasValidAzApi:       - response_export_values    = [
TestDeploySubscriptionAliasValidAzApi:           - "properties.subscriptionId",
TestDeploySubscriptionAliasValidAzApi:         ] -> null
TestDeploySubscriptionAliasValidAzApi:       - schema_validation_enabled = true -> null
TestDeploySubscriptionAliasValidAzApi:       - tags                      = {} -> null
TestDeploySubscriptionAliasValidAzApi:       - type                      = "Microsoft.Subscription/aliases@2021-10-01" -> null
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # azapi_resource_action.subscription_rename[0] will be destroyed
TestDeploySubscriptionAliasValidAzApi:   - resource "azapi_resource_action" "subscription_rename" {
TestDeploySubscriptionAliasValidAzApi:       - action      = "providers/Microsoft.Subscription/rename" -> null
TestDeploySubscriptionAliasValidAzApi:       - body        = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               - subscriptionName = "testdeploy-a29a28fe"
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         ) -> null
TestDeploySubscriptionAliasValidAzApi:       - id          = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Subscription/rename" -> null
TestDeploySubscriptionAliasValidAzApi:       - method      = "POST" -> null
TestDeploySubscriptionAliasValidAzApi:       - output      = jsonencode({})
TestDeploySubscriptionAliasValidAzApi:       - resource_id = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72" -> null
TestDeploySubscriptionAliasValidAzApi:       - type        = "Microsoft.Resources/subscriptions@2021-10-01" -> null
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # azapi_update_resource.subscription_tags[0] will be destroyed
TestDeploySubscriptionAliasValidAzApi:   - resource "azapi_update_resource" "subscription_tags" {
TestDeploySubscriptionAliasValidAzApi:       - body                    = jsonencode(
TestDeploySubscriptionAliasValidAzApi:             {
TestDeploySubscriptionAliasValidAzApi:               - properties = {
TestDeploySubscriptionAliasValidAzApi:                   - tags = {}
TestDeploySubscriptionAliasValidAzApi:                 }
TestDeploySubscriptionAliasValidAzApi:             }
TestDeploySubscriptionAliasValidAzApi:         ) -> null
TestDeploySubscriptionAliasValidAzApi:       - id                      = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Resources/tags/default" -> null
TestDeploySubscriptionAliasValidAzApi:       - ignore_casing           = false -> null
TestDeploySubscriptionAliasValidAzApi:       - ignore_missing_property = true -> null
TestDeploySubscriptionAliasValidAzApi:       - name                    = "default" -> null
TestDeploySubscriptionAliasValidAzApi:       - output                  = jsonencode({})
TestDeploySubscriptionAliasValidAzApi:       - parent_id               = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72" -> null
TestDeploySubscriptionAliasValidAzApi:       - resource_id             = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Resources/tags/default" -> null
TestDeploySubscriptionAliasValidAzApi:       - type                    = "Microsoft.Resources/tags@2022-09-01" -> null
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi:   # time_sleep.wait_for_subscription_before_subscription_operations[0] will be destroyed
TestDeploySubscriptionAliasValidAzApi:   - resource "time_sleep" "wait_for_subscription_before_subscription_operations" {
TestDeploySubscriptionAliasValidAzApi:       - create_duration  = "30s" -> null
TestDeploySubscriptionAliasValidAzApi:       - destroy_duration = "0s" -> null
TestDeploySubscriptionAliasValidAzApi:       - id               = "2023-12-06T16:55:09Z" -> null
TestDeploySubscriptionAliasValidAzApi:     }
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Plan: 0 to add, 0 to change, 4 to destroy.
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Changes to Outputs:
TestDeploySubscriptionAliasValidAzApi:   - subscription_id          = "6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72" -> null
TestDeploySubscriptionAliasValidAzApi:   - subscription_resource_id = "/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72" -> null
TestDeploySubscriptionAliasValidAzApi: azapi_update_resource.subscription_tags[0]: Destroying... [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Resources/tags/default]
TestDeploySubscriptionAliasValidAzApi: azapi_resource_action.subscription_rename[0]: Destroying... [id=/subscriptions/6e284ae6-4d78-4cdc-9cbb-0fdae2f2bb72/providers/Microsoft.Subscription/rename]
TestDeploySubscriptionAliasValidAzApi: azapi_update_resource.subscription_tags[0]: Destruction complete after 0s
TestDeploySubscriptionAliasValidAzApi: azapi_resource_action.subscription_rename[0]: Destruction complete after 0s
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Destroying... [id=2023-12-06T16:55:09Z]
TestDeploySubscriptionAliasValidAzApi: time_sleep.wait_for_subscription_before_subscription_operations[0]: Destruction complete after 0s
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Destroying... [id=/providers/Microsoft.Subscription/aliases/testdeploy-a29a28fe]
TestDeploySubscriptionAliasValidAzApi: azapi_resource.subscription[0]: Destruction complete after 3s
TestDeploySubscriptionAliasValidAzApi:
TestDeploySubscriptionAliasValidAzApi: Destroy complete! Resources: 4 destroyed.
--- PASS: TestDeploySubscriptionAliasValidAzApi (134.66s)
```
</details>
## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [x] Created unit and deployment tests and provided evidence.
- [] Updated relevant and associated documentation.
