### PR TITLE
fix: update inbound peering useRemoteGateways to false

### DIFF
--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "4.0.1"
+    "module_version": "4.0.2"
   }
 }

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -130,7 +130,7 @@ resource "azapi_resource" "peering_hub_inbound" {
       allowVirtualNetworkAccess = true
       allowForwardedTraffic     = true
       allowGatewayTransit       = true
-      useRemoteGateways         = each.value.use_remote_gateways
+      useRemoteGateways         = false
     }
   })
 }


### PR DESCRIPTION
fixes bug: hub_peering_use_remote_gateways should not try to enable use_remote_gateways for both the spoke and the hub network with a single setting #334

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Fix use remote gateway issue wih inbound peering

## This PR fixes/adds/changes/removes

1. fixes #334



## Testing evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
