### PR TITLE
fix: subscription display name & alias validation rule

### DIFF
--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "4.1.2"
+    "module_version": "4.1.3"
   }
 }

--- a/modules/subscription/README.md
+++ b/modules/subscription/README.md
@@ -116,7 +116,7 @@ Default: `""`
 Description: The display name of the subscription alias.
 
 The string must be comprised of a-z, A-Z, 0-9, -, \_ and space.  
-The maximum length is 63 characters.
+The maximum length is 64 characters.
 
 You may also supply an empty string if you do not want to create a new subscription alias.  
 In this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -38,8 +38,8 @@ You may also supply an empty string if you do not want to create a new subscript
 In this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.
 DESCRIPTION
   validation {
-    condition     = can(regex("^$|^[a-zA-Z0-9-_]{1,63}$", var.subscription_alias_name))
-    error_message = "Valid characters are a-z, A-Z, 0-9, -, _."
+    condition     = length(var.subscription_alias_name) <= 64 && !can(regex("[<>;|]", var.subscription_alias_name))
+    error_message = "Subscription Alias must either \"\", or be less or equal to 64 characters in length and cannot contain the characters `<`, `>`, `;`, or `|`"
   }
 }
 
@@ -50,14 +50,14 @@ variable "subscription_display_name" {
 The display name of the subscription alias.
 
 The string must be comprised of a-z, A-Z, 0-9, -, _ and space.
-The maximum length is 63 characters.
+The maximum length is 64 characters.
 
 You may also supply an empty string if you do not want to create a new subscription alias.
 In this scenario, `subscription_enabled` should be set to `false` and `subscription_id` must be supplied.
 DESCRIPTION
   validation {
-    condition     = can(regex("^$|^[a-zA-Z0-9-_ ]{1,63}$", var.subscription_display_name))
-    error_message = "Valid characters are a-z, A-Z, 0-9, -, _, and space."
+    condition     = length(var.subscription_display_name) > 0 && length(var.subscription_display_name) <= 64 && !can(regex("[<>;|]", var.subscription_display_name))
+    error_message = "Subscription Name must be between 1 and 64 characters in length and cannot contain the characters `<`, `>`, `;`, or `|`"
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Updates the validation rule to align with the hashicorp provider code. 

## This PR fixes/adds/changes/removes

1. fixes #373

### Breaking changes

No.

## Testing evidence

Deployed into a sub with brackets in the name.

## As part of this pull request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [X] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [X] Updated relevant and associated documentation.
