### PR TITLE
feat: support for route tables & routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Source: ./modules/roleassignment
 
 Version:
 
+### <a name="module_routetable"></a> [routetable](#module\_routetable)
+
+Source: ./modules/routetable
+
+Version:
+
 ### <a name="module_subscription"></a> [subscription](#module\_subscription)
 
 Source: ./modules/subscription
@@ -416,6 +422,49 @@ map(object({
     relative_scope    = optional(string, ""),
     condition         = optional(string, ""),
     condition_version = optional(string, ""),
+  }))
+```
+
+Default: `{}`
+
+### <a name="input_route_table_enabled"></a> [route\_table\_enabled](#input\_route\_table\_enabled)
+
+Description: Whether to create route tables and routes in the target subscription. Requires `var.route_tables`.
+
+Type: `bool`
+
+Default: `false`
+
+### <a name="input_route_tables"></a> [route\_tables](#input\_route\_tables)
+
+Description: A map defining route tables and their associated routes to be created.
+  - `name` (required): The name of the route table.
+  - `location` (required): The location of the resource group.
+  - `resource_group_name` (required): The name of the resource group.
+  - `disable_bgp_route_propagation` (optional): Boolean that controls whether routes learned by BGP are propagated to the route table.
+  - `tags` (optional): A map of key-value pairs for tags associated with the route table.
+  - `routes` (optional): A map defining routes for the route table. Each route object has the following properties:
+      - `name` (required): The name of the route.
+      - `address_prefix` (required): The address prefix for the route.
+      - `next_hop_type` (required): The type of next hop for the route.
+      - `next_hop_in_ip_address` (required): The next hop IP address for the route.
+
+Type:
+
+```hcl
+map(object({
+    name                          = string
+    location                      = string
+    resource_group_name           = string
+    disable_bgp_route_propagation = optional(bool, false)
+    tags                          = optional(map(string))
+
+    routes = optional(map(object({
+      name                   = string
+      address_prefix         = string
+      next_hop_type          = string
+      next_hop_in_ip_address = string
+    })))
   }))
 ```
 

--- a/main.routetable.tf
+++ b/main.routetable.tf
@@ -1,0 +1,12 @@
+# route table submodule, disabled by default
+# Will create a route table, and optionally routes
+module "routetable" {
+  source          = "./modules/routetable"
+  count           = var.route_table_enabled ? 1 : 0
+  subscription_id = local.subscription_id
+
+  route_tables = var.route_tables
+  depends_on = [
+    module.resourcegroup,
+  ]
+}

--- a/modules/routetable/README.md
+++ b/modules/routetable/README.md
@@ -47,7 +47,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.94)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.11.0)
 
 ## Modules
 
@@ -105,7 +105,7 @@ Default: `{}`
 
 The following resources are used by this module:
 
-- [azapi_resource.route_table](https://registry.terraform.io/providers/hashicorp/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.route_table](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
 
 ## Outputs
 

--- a/modules/routetable/README.md
+++ b/modules/routetable/README.md
@@ -1,0 +1,115 @@
+<!-- BEGIN_TF_DOCS -->
+# Landing zone route table submodule
+
+## Overview
+
+Creates multiple route tables in the supplied subscription.
+Optionally:
+
+- Creates routes within the route tables
+
+## Notes
+
+See [README.md](https://github.com/Azure/terraform-azurerm-lz-vending#readme) in the parent module for more information.
+
+## Example
+
+See documentation for optional parameters.
+
+```terraform
+module "routetable" {
+  source  = "Azure/lz-vending/azurerm/modules/routetable"
+  version = "<version>" # change this to your desired version, https://www.terraform.io/language/expressions/version-constraints
+
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  route_tables = {
+    rt1 = {
+      name                   = "myroutetable"
+      address_prefix         = ["192.168.0.0/24"]
+      next_hop_in_ip_address = "192.168.0.5"
+      next_hop_type          = "VirtualAppliance"
+    },
+    rt2 = {
+      name           = "myroutetable2"
+      address_prefix = "GatewayManager"
+      next_hop_type  = "Internet"
+    }
+  }
+}
+```
+
+## Documentation
+<!-- markdownlint-disable MD033 -->
+
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5.0)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.94)
+
+## Modules
+
+No modules.
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id)
+
+Description: The subscription ID of the subscription to create the virtual network in.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_route_tables"></a> [route\_tables](#input\_route\_tables)
+
+Description: A map defining route tables and their associated routes to be created.
+  - `name` (required): The name of the route table.
+  - `location` (required): The location of the resource group.
+  - `resource_group_name` (required): The name of the resource group.
+  - `tags` (optional): A map of key-value pairs for tags associated with the route table.
+  - `routes` (optional): A map defining routes for the route table. Each route object has the following properties:
+      - `name` (required): The name of the route.
+      - `address_prefix` (required): The address prefix for the route.
+      - `next_hop_type` (required): The type of next hop for the route.
+      - `next_hop_in_ip_address` (required): The next hop IP address for the route.
+
+Type:
+
+```hcl
+map(object({
+    name                = string
+    location            = string
+    resource_group_name = string
+    tags                = optional(map(string))
+
+    routes = optional(map(object({
+      name                   = string
+      address_prefix         = string
+      next_hop_type          = string
+      next_hop_in_ip_address = string
+    })))
+  }))
+```
+
+Default: `{}`
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource.route_table](https://registry.terraform.io/providers/hashicorp/azapi/latest/docs/resources/resource) (resource)
+
+## Outputs
+
+No outputs.
+
+<!-- markdownlint-enable -->
+<!-- END_TF_DOCS -->

--- a/modules/routetable/header.md
+++ b/modules/routetable/header.md
@@ -1,0 +1,38 @@
+# Landing zone route table submodule
+
+## Overview
+
+Creates multiple route tables in the supplied subscription.
+Optionally:
+
+- Creates routes within the route tables
+
+## Notes
+
+See [README.md](https://github.com/Azure/terraform-azurerm-lz-vending#readme) in the parent module for more information.
+
+## Example
+
+See documentation for optional parameters.
+
+```terraform
+module "routetable" {
+  source  = "Azure/lz-vending/azurerm/modules/routetable"
+  version = "<version>" # change this to your desired version, https://www.terraform.io/language/expressions/version-constraints
+
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  route_tables = {
+    rt1 = {
+      name                   = "myroutetable"
+      address_prefix         = ["192.168.0.0/24"]
+      next_hop_in_ip_address = "192.168.0.5"
+      next_hop_type          = "VirtualAppliance"
+    },
+    rt2 = {
+      name           = "myroutetable2"
+      address_prefix = "GatewayManager"
+      next_hop_type  = "Internet"
+    }
+  }
+}
+```

--- a/modules/routetable/locals.tf
+++ b/modules/routetable/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # subscription_resource_id is the ARM resource ID of the supplied subscription id.
+  subscription_resource_id = "/subscriptions/${var.subscription_id}"
+}

--- a/modules/routetable/main.tf
+++ b/modules/routetable/main.tf
@@ -1,0 +1,26 @@
+resource "azapi_resource" "route_table" {
+  for_each = var.route_tables
+
+  type      = "Microsoft.Network/routeTables@2023-04-01"
+  parent_id = "${local.subscription_resource_id}/resourceGroups/${each.value.resource_group_name}"
+  name      = each.value.name
+  location  = each.value.location
+  body = {
+    properties = {
+      disableBgpRoutePropagation = try(each.value.disable_bgp_route_propagation, false)
+      routes = each.value.routes != null ? [
+        for r in each.value.routes : {
+          name = r.name
+          properties = {
+            addressPrefix    = r.address_prefix
+            nextHopIpAddress = r.next_hop_in_ip_address
+            nextHopType      = r.next_hop_type
+          }
+        }
+      ] : null
+    }
+  }
+  schema_validation_enabled = true
+  response_export_values    = ["*"]
+  tags                      = each.value.tags
+}

--- a/modules/routetable/main.tf
+++ b/modules/routetable/main.tf
@@ -5,7 +5,7 @@ resource "azapi_resource" "route_table" {
   parent_id = "${local.subscription_resource_id}/resourceGroups/${each.value.resource_group_name}"
   name      = each.value.name
   location  = each.value.location
-  body = {
+  body = jsonencode({
     properties = {
       disableBgpRoutePropagation = try(each.value.disable_bgp_route_propagation, false)
       routes = each.value.routes != null ? [
@@ -19,7 +19,7 @@ resource "azapi_resource" "route_table" {
         }
       ] : null
     }
-  }
+  })
   schema_validation_enabled = true
   response_export_values    = ["*"]
   tags                      = each.value.tags

--- a/modules/routetable/terraform.tf
+++ b/modules/routetable/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.94"
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 1.11.0"
     }
   }
   required_version = ">= 1.5.0"

--- a/modules/routetable/terraform.tf
+++ b/modules/routetable/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.94"
+    }
+  }
+  required_version = ">= 1.5.0"
+}

--- a/modules/routetable/variables.tf
+++ b/modules/routetable/variables.tf
@@ -1,0 +1,40 @@
+variable "subscription_id" {
+  type        = string
+  description = <<DESCRIPTION
+The subscription ID of the subscription to create the virtual network in.
+DESCRIPTION
+  validation {
+    condition     = can(regex("^[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}$", var.subscription_id))
+    error_message = "Must a GUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx. All letters must be lowercase."
+  }
+}
+
+variable "route_tables" {
+  type = map(object({
+    name                = string
+    location            = string
+    resource_group_name = string
+    tags                = optional(map(string))
+
+    routes = optional(map(object({
+      name                   = string
+      address_prefix         = string
+      next_hop_type          = string
+      next_hop_in_ip_address = string
+    })))
+  }))
+  description = <<DESCRIPTION
+A map defining route tables and their associated routes to be created.
+  - `name` (required): The name of the route table.
+  - `location` (required): The location of the resource group.
+  - `resource_group_name` (required): The name of the resource group.
+  - `tags` (optional): A map of key-value pairs for tags associated with the route table.
+  - `routes` (optional): A map defining routes for the route table. Each route object has the following properties:
+      - `name` (required): The name of the route.
+      - `address_prefix` (required): The address prefix for the route.
+      - `next_hop_type` (required): The type of next hop for the route.
+      - `next_hop_in_ip_address` (required): The next hop IP address for the route.
+DESCRIPTION
+  nullable    = false
+  default     = {}
+}

--- a/variables.routetable.tf
+++ b/variables.routetable.tf
@@ -1,0 +1,37 @@
+variable "route_table_enabled" {
+  type        = bool
+  description = "Whether to create route tables and routes in the target subscription. Requires `var.route_tables`."
+  default     = false
+}
+
+variable "route_tables" {
+  type = map(object({
+    name                          = string
+    location                      = string
+    resource_group_name           = string
+    disable_bgp_route_propagation = optional(bool, false)
+    tags                          = optional(map(string))
+
+    routes = optional(map(object({
+      name                   = string
+      address_prefix         = string
+      next_hop_type          = string
+      next_hop_in_ip_address = string
+    })))
+  }))
+  description = <<DESCRIPTION
+A map defining route tables and their associated routes to be created.
+  - `name` (required): The name of the route table.
+  - `location` (required): The location of the resource group.
+  - `resource_group_name` (required): The name of the resource group.
+  - `disable_bgp_route_propagation` (optional): Boolean that controls whether routes learned by BGP are propagated to the route table.
+  - `tags` (optional): A map of key-value pairs for tags associated with the route table.
+  - `routes` (optional): A map defining routes for the route table. Each route object has the following properties:
+      - `name` (required): The name of the route.
+      - `address_prefix` (required): The address prefix for the route.
+      - `next_hop_type` (required): The type of next hop for the route.
+      - `next_hop_in_ip_address` (required): The next hop IP address for the route.
+DESCRIPTION
+  nullable    = false
+  default     = {}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

This introduces support for route tables & routes.  It has been added to support the default route issue, but is generic so can be used to create any route table & route.

I have kept it pinned to azapi 1.11 noting the changes required to bump to 1.13.1

## This PR fixes/adds/changes/removes

1. fixes #218 

### Breaking changes

n/a new change

## Testing evidence

I have tested this on my integration branch [here](https://github.com/kewalaka/terraform-azurerm-lz-vending/tree/integration_test), based on the following inputs (and no input)

![image](https://github.com/Azure/terraform-azurerm-lz-vending/assets/3146590/196d3f74-05aa-424d-9810-c27ffaa6a52d)

deployed;

![image](https://github.com/Azure/terraform-azurerm-lz-vending/assets/3146590/885dccec-b1a9-4d24-bdf3-7b2599a881a3)

## As part of this pull request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [X] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence. _edit_ - yes to deployment tests
- [X] Updated relevant and associated documentation.

I'm not familiar with the unit test approach, guidance would be appreciated 😊