### PR TITLE
feat: add subscription_tags_ignored variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,24 @@ Type: `map(string)`
 
 Default: `{}`
 
+### <a name="input_subscription_tags_ignored"></a> [subscription\_tags_ignored](#input\_subscription\_tags_ignored)
+
+Drescription: A list of tags to ignore changes on when updating the subscription.
+
+Example value:
+
+```terraform
+subscription_tags_ignored = [
+  tags["mytag"],
+  tags["mytag2"],
+  tags["mytag3"]
+]
+```
+
+Type: `list(string)`
+
+Default: `[]`
+
 ### <a name="input_subscription_update_existing"></a> [subscription\_update\_existing](#input\_subscription\_update\_existing)
 
 Description: Whether to update an existing subscription with the supplied tags and display name.  

--- a/main.subscription.tf
+++ b/main.subscription.tf
@@ -13,6 +13,7 @@ module "subscription" {
   subscription_management_group_association_enabled    = var.subscription_management_group_association_enabled
   subscription_management_group_id                     = var.subscription_management_group_id
   subscription_tags                                    = var.subscription_tags
+  subscription_tags_ignored                            = var.subscription_tags_ignored 
   subscription_use_azapi                               = var.subscription_use_azapi
   subscription_update_existing                         = var.subscription_update_existing
   subscription_workload                                = var.subscription_workload

--- a/main.subscription.tf
+++ b/main.subscription.tf
@@ -13,7 +13,7 @@ module "subscription" {
   subscription_management_group_association_enabled    = var.subscription_management_group_association_enabled
   subscription_management_group_id                     = var.subscription_management_group_id
   subscription_tags                                    = var.subscription_tags
-  subscription_tags_ignored                            = var.subscription_tags_ignored 
+  subscription_tags_ignored                            = var.subscription_tags_ignored
   subscription_use_azapi                               = var.subscription_use_azapi
   subscription_update_existing                         = var.subscription_update_existing
   subscription_workload                                = var.subscription_workload

--- a/modules/subscription/README.md
+++ b/modules/subscription/README.md
@@ -173,6 +173,24 @@ Type: `map(string)`
 
 Default: `{}`
 
+### <a name="input_subscription_tags_ignored"></a> [subscription\_tags_ignored](#input\_subscription\_tags_ignored)
+
+Drescription: A list of tags to ignore changes on when updating the subscription.
+
+Example value:
+
+```terraform
+subscription_tags_ignored = [
+  tags["mytag"],
+  tags["mytag2"],
+  tags["mytag3"]
+]
+```
+
+Type: `list(string)`
+
+Default: `[]`
+
 ### <a name="input_subscription_update_existing"></a> [subscription\_update\_existing](#input\_subscription\_update\_existing)
 
 Description: Whether to update an existing subscription with the supplied tags and display name.  

--- a/modules/subscription/main.tf
+++ b/modules/subscription/main.tf
@@ -6,6 +6,10 @@ resource "azurerm_subscription" "this" {
   billing_scope_id  = var.subscription_billing_scope
   workload          = var.subscription_workload
   tags              = var.subscription_tags
+
+  lifecycle {
+    ignore_changes = var.subscription_tags_ignored
+  }
 }
 
 # This resource ensures that we can manage the management group for the subscription

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -169,8 +169,8 @@ DESCRIPTION
 }
 
 variable "subscription_tags_ignored" {
-  type = list(string)
-  default =  []
+  type        = list(string)
+  default     = []
   description = <<DESCRIPTION
 A list of tags to ignore changes on when updating the subscription.
 

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -168,6 +168,24 @@ DESCRIPTION
   }
 }
 
+variable "subscription_tags_ignored" {
+  type = list(string)
+  default =  []
+  description = <<DESCRIPTION
+A list of tags to ignore changes on when updating the subscription.
+
+Example value:
+
+```terraform
+subscription_tags_ignored = [
+  tags["mytag"],
+  tags["mytag2"],
+  tags["mytag3"]
+]
+```
+DESCRIPTION
+}
+
 variable "subscription_use_azapi" {
   type        = bool
   default     = false

--- a/variables.subscription.tf
+++ b/variables.subscription.tf
@@ -156,6 +156,24 @@ DESCRIPTION
   default     = {}
 }
 
+variable "subscription_tags_ignored" {
+  type = list(string)
+  default =  []
+  description = <<DESCRIPTION
+A list of tags to ignore changes on when updating the subscription.
+
+Example value:
+
+```terraform
+subscription_tags_ignored = [
+  tags["mytag",
+  tags["mytag2"],
+  tags["mytag3"]
+]
+```
+DESCRIPTION
+}
+
 variable "subscription_use_azapi" {
   type        = bool
   default     = false

--- a/variables.subscription.tf
+++ b/variables.subscription.tf
@@ -157,8 +157,8 @@ DESCRIPTION
 }
 
 variable "subscription_tags_ignored" {
-  type = list(string)
-  default =  []
+  type        = list(string)
+  default     = []
   description = <<DESCRIPTION
 A list of tags to ignore changes on when updating the subscription.
 


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

This PR adds the `subscription_tags_ignored` variable to the subscription module. This variable allows users to specify a list of tags to ignore when updating the subscription.

In one customer scenario, the customer has internal cost center information that is applied and updated as tags to the subscription outside of the vending module. Running the Terraform deployment results in overwriting the tags, so we need the ability to ignore certain tags.

## Testing evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
