### PR TITLE
fix: remove redundant resource provider

### DIFF
--- a/variables.resourceprovider.tf
+++ b/variables.resourceprovider.tf
@@ -82,7 +82,6 @@ DESCRIPTION
     "Microsoft.Sql"                     = [],
     "Microsoft.Storage"                 = [],
     "Microsoft.StreamAnalytics"         = [],
-    "Microsoft.TimeSeriesInsights"      = [],
     "Microsoft.Web"                     = [],
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Remove the Microsoft.TimeSeriesInsights resource provider that has been removed from Azure. 

## This PR fixes/adds/changes/removes

1. fixes #000

### Breaking changes

1. *Replace me*

## Testing evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this pull request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
