### PR TITLE
Add tag feature for networkwatcher RG

### DIFF
--- a/main.resourcegroup.tf
+++ b/main.resourcegroup.tf
@@ -15,7 +15,7 @@ module "resourcegroup_networkwatcherrg" {
   subscription_id     = local.subscription_id
   location            = var.location
   resource_group_name = "NetworkWatcherRG"
-  tags                = {}
+  tags                = var.network_watcher_resource_group_tags
 }
 
 

--- a/variables.resourcegroup.tf
+++ b/variables.resourcegroup.tf
@@ -11,6 +11,11 @@ which includes destroying the resource (and all resources within it).
 DESCRIPTION
   default     = false
 }
+variable "network_watcher_resource_group_tags" {
+  type        = map(string)
+  description = "Tags for `NetworkWatcherRG` in the subscription."
+  default = {}
+}
 
 variable "resource_group_creation_enabled" {
   type        = bool

--- a/variables.resourcegroup.tf
+++ b/variables.resourcegroup.tf
@@ -11,6 +11,7 @@ which includes destroying the resource (and all resources within it).
 DESCRIPTION
   default     = false
 }
+
 variable "network_watcher_resource_group_tags" {
   type        = map(string)
   description = "Tags for `NetworkWatcherRG` in the subscription."


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Allow configuring tags on networkWatcher resource group by using an optional variable which default to an empty map. fixes 

- #420 

This feature is practical for scenario where tags are inherited from subscription using azure policies

## Testing evidence

without this modification, terraform would always detect drift (if azure policies modify the tags).

allowing to set tag on networkWatcher resource group using an input variable

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.