### PR TITLE
Create additional output in LZ virtualnetwork submodule to enable referring to VNET names in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,10 @@ Description: A map of resource group ids, keyed by the var.virtual\_networks inp
 
 Description: A map of virtual network resource ids, keyed by the var.virtual\_networks input map. Only populated if the virtualnetwork submodule is enabled.
 
+### <a name="output_virtual_network_resource_names"></a> [virtual\_network\_resource\_names](#output\_virtual\_network\_resource\_names)
+
+Description: A map of virtual network resource names, keyed by the var.virtual\_networks input map. Only populated if the virtualnetwork submodule is enabled.
+
 <!-- markdownlint-enable -->
 <!-- markdownlint-disable MD041 -->
 ## Telemetry

--- a/locals.tf
+++ b/locals.tf
@@ -26,6 +26,10 @@ locals {
   # This is used in the outputs.tf file to return the virtual network resource ids.
   virtual_network_resource_ids = var.virtual_network_enabled ? module.virtualnetwork[0].virtual_network_resource_ids : {}
 
+  # virtual_networks_merged is a map of virtual networks created, if the module has been enabled.
+  # This is used in the outputs.tf file to return the virtual network resource ids.
+  virtual_network_resource_names = var.virtual_network_enabled ? module.virtualnetwork[0].virtual_network_resource_names : {}
+
   # resource_group_ids is a map of resource groups created, if the module has been enabled.
   # This is used in the outputs.tf file to return the resource group ids.
   virtual_network_resource_group_ids = var.virtual_network_enabled ? module.virtualnetwork[0].resource_group_ids : {}

--- a/modules/virtualnetwork/outputs.tf
+++ b/modules/virtualnetwork/outputs.tf
@@ -5,6 +5,13 @@ output "virtual_network_resource_ids" {
   }
 }
 
+output "virtual_network_names" {
+  description = "The created virtual network names, expressed as a map"
+  value = {
+    for k, v in azapi_resource.vnet : k => v.name
+  }
+}
+
 output "resource_group_ids" {
   description = "The created resource group IDs, expressed as a map."
   value = {

--- a/modules/virtualnetwork/outputs.tf
+++ b/modules/virtualnetwork/outputs.tf
@@ -5,7 +5,7 @@ output "virtual_network_resource_ids" {
   }
 }
 
-output "virtual_network_names" {
+output "virtual_network_resource_names" {
   description = "The created virtual network names, expressed as a map"
   value = {
     for k, v in azapi_resource.vnet : k => v.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "virtual_network_resource_group_ids" {
   description = "A map of resource group ids, keyed by the var.virtual_networks input map. Only populated if the virtualnetwork submodule is enabled."
 }
 
+output "virtual_network_resource_names" {
+  value       = local.virtual_network_resource_names
+  description = "A map of virtual network resource names, keyed by the var.virtual_networks input map. Only populated if the virtualnetwork submodule is enabled."
+}
+
 output "management_group_subscription_association_id" {
   value       = var.subscription_management_group_association_enabled ? module.subscription[0].management_group_subscription_association_id : null
   description = <<DESCRIPTION


### PR DESCRIPTION

# Overview/summary

Additional output in both virtualnetwork and main module will make it possible to refer to VNETs created in lz_vending module by name. This in turn will make it possible to create subnets within those VNETs in the same configuration file.

## This PR fixes/adds/changes/removes

Adds two outputs.

### Breaking changes

N/A.

## Testing evidence

![405774584-d60136a2-1711-48a4-adf4-eff4e02ad1cf](https://github.com/user-attachments/assets/efbad4dd-e462-432f-9cdc-1c7cedc7f2c0)


If I run the terraform plan with the config above and try to create a subnet it is impossible to refer to previously created VNETS (below) by name regardless of what's in 'virtual_network_name'


![image](https://github.com/user-attachments/assets/747a28e9-6937-40a7-be4f-5277b1107f1a)


With outputs I am able to create subnets within VNETs created by module:


![image](https://github.com/user-attachments/assets/3c0d0c1b-22a3-4944-9eec-5204bd463e62)


## As part of this pull request I have

- [v] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [V] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [V] Created unit and deployment tests and provided evidence.
- [V] Updated relevant and associated documentation.
