### PR TITLE
fix: set relative scope values to default empty string to avoid null interpolation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ map(object({
     time_grain        = string
     time_period_start = string
     time_period_end   = string
-    relative_scope    = optional(string)
+    relative_scope    = optional(string, "")
     notifications = optional(map(object({
       enabled        = bool
       operator       = string
@@ -403,7 +403,7 @@ Type:
 map(object({
     principal_id              = string,
     definition                = string,
-    relative_scope            = optional(string)
+    relative_scope            = optional(string, "")
     condition                 = optional(string)
     condition_version         = optional(string)
     principal_type            = optional(string)
@@ -784,7 +784,7 @@ map(object({
     resource_group_lock_name    = optional(string)
     role_assignments = optional(map(object({
       definition                = string
-      relative_scope            = optional(string)
+      relative_scope            = optional(string, "")
       condition                 = optional(string)
       condition_version         = optional(string)
       principal_type            = optional(string)

--- a/variables.budget.tf
+++ b/variables.budget.tf
@@ -13,7 +13,7 @@ variable "budgets" {
     time_grain        = string
     time_period_start = string
     time_period_end   = string
-    relative_scope    = optional(string)
+    relative_scope    = optional(string, "")
     notifications = optional(map(object({
       enabled        = bool
       operator       = string

--- a/variables.roleassignment.tf
+++ b/variables.roleassignment.tf
@@ -11,7 +11,7 @@ variable "role_assignments" {
   type = map(object({
     principal_id              = string,
     definition                = string,
-    relative_scope            = optional(string)
+    relative_scope            = optional(string, "")
     condition                 = optional(string)
     condition_version         = optional(string)
     principal_type            = optional(string)

--- a/variables.usermanagedidentity.tf
+++ b/variables.usermanagedidentity.tf
@@ -19,7 +19,7 @@ variable "user_managed_identities" {
     resource_group_lock_name    = optional(string)
     role_assignments = optional(map(object({
       definition                = string
-      relative_scope            = optional(string)
+      relative_scope            = optional(string, "")
       condition                 = optional(string)
       condition_version         = optional(string)
       principal_type            = optional(string)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Reverts previous change and sets empty string for these values to prevent null interpolation

## This PR fixes/adds/changes/removes

1. fixes #452

## Testing evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this pull request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
