### PR TITLE
Ene customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,4 +1278,4 @@ Authorized use of Microsoft trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
-<!-- END_TF_DOCS -->
+<!-- END_TF_DOCS --># Skagrak Energi customizations for v5.1.2

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   # subscription_id is the id of the subscription into which resources will be created.
   # We pick the created sub id first, if it exists, otherwise we pick the subscription_id variable.
-  subscription_id = coalesce(local.subscription_module_output_subscription_id, var.subscription_id)
+  subscription_id = coalesce(var.subscription_id, local.subscription_module_output_subscription_id)
   # subscription_module_output_subscription_id is either the output of the subscription module,
   # or if disabled, a null.
   # Needed to avoid errors in local.subscription_id when referencing a module instance that does not exists.

--- a/modules/subscription/locals.tf
+++ b/modules/subscription/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # subscription_id is the id of the newly created subscription, or the id supplied by var.subscription_id.
-  subscription_id = coalesce(local.subscription_id_alias, var.subscription_id)
+  subscription_id = coalesce(var.subscription_id, local.subscription_id_alias)
   # subscription_id_alias is the id of the newly created subscription, if it exists.
   subscription_id_alias = try(azapi_resource.subscription[0].output.properties.subscriptionId, null)
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

The problem we faced, was for the edge case when you want to import existing landing zone subscriptions, in a allready established alz architecture, into a new terraform state.
The dynamically resolved 'local.subscription_id_alias' took priority, which forced a recreate of the subscriptions regardless after a import.

## This PR fixes/adds/changes/removes

1. fixes #487 the coalesce priority, to prioritize the static subscription id variable first. If provided.

### Breaking changes

1. If user has provided a static subscription id, after creation, the dynamically resolved one would have been taken priority. So if they have misconfigured a wrong subscription id statically as input, in that scenario this change might unexpectingly cause their subscription to be destroyed. **very edge case, but possible if allready misconfigured**

## Testing evidence

We did this as part of a migration process, when we migrated our monolith statefile, into one state per landing zone. This fix made this possible, and after perfoming the initial migration with this fix on our own fork, we could switch back to the official version.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [-] Created unit and deployment tests and provided evidence.
- [x] Updated relevant and associated documentation.
