### PR TITLE
FIX: Virtual Network Resource Group dependency

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -134,6 +134,24 @@ locals {
   # This is used in the outputs.tf file to return the virtual network resource ids.
   virtual_network_resource_ids = var.virtual_network_enabled ? module.virtualnetwork[0].virtual_network_resource_ids : {}
 
+  # resource_group_data is the unique set of resource groups to create to support the virtual network resources
+  resource_group_data = {
+    for v in var.virtual_networks : v.resource_group_name => {
+      name     = v.resource_group_name
+      location = coalesce(v.location, var.location)
+      # lock      = v.resource_group_lock_enabled
+      # lock_name = v.resource_group_lock_name
+      tags = v.resource_group_tags
+    }
+    if v.resource_group_creation_enabled
+  }
+
+  resource_groups = var.resource_group_creation_enabled ? merge(
+    var.resource_groups,
+    local.resource_group_data
+  ) : local.resource_group_data
+
+
   # route_table_routes is a list of objects containing the routes that need to be converted from a map to a list to match the submodule input variable definition.
   route_tables = {
     for rt_k, rt_v in var.route_tables : rt_k => {

--- a/main.resourcegroup.tf
+++ b/main.resourcegroup.tf
@@ -1,7 +1,7 @@
 # Resource groups module
 module "resourcegroup" {
   source              = "./modules/resourcegroup"
-  for_each            = var.resource_group_creation_enabled ? var.resource_groups : {}
+  for_each            = length(local.resource_groups) > 0 ? local.resource_groups : {}
   subscription_id     = local.subscription_id
   location            = each.value.location
   resource_group_name = each.value.name

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -1,19 +1,16 @@
-# azapi_resource.rg is the resource group that the virtual network will be created in
-# the module will create as many as is required by the var.virtual_networks input variable
-resource "azapi_resource" "rg" {
-  for_each = { for i in local.resource_group_data : i.name => i }
-
-  type      = "Microsoft.Resources/resourceGroups@2021-04-01"
-  location  = each.value.location
-  name      = each.key
-  parent_id = local.subscription_resource_id
-  tags      = each.value.tags
-}
-
 # azapi_resource.rg_lock is an optional resource group lock that can be used
 # to prevent accidental deletion.
 resource "azapi_resource" "rg_lock" {
-  for_each = { for i in local.resource_group_data : i.name => i if i.lock }
+  # for_each = { for i in local.resource_group_data : i.name => i if i.lock }
+  for_each = {
+    for k, v in var.virtual_networks :
+    v.name => {
+      lock_name = v.resource_group_lock_name
+      lock      = v.resource_group_lock_enabled
+      vnet_key  = k
+    }
+    if try(v.resource_group_lock_enabled, false)
+  }
 
   type = "Microsoft.Authorization/locks@2017-04-01"
   body = {
@@ -22,10 +19,10 @@ resource "azapi_resource" "rg_lock" {
     }
   }
   name      = coalesce(each.value.lock_name, substr("lock-${each.key}", 0, 90))
-  parent_id = azapi_resource.rg[each.key].id
+  parent_id = module.virtual_networks[each.key].resource.parent_id
 
   depends_on = [
-    module.virtual_networks,
+
     module.peering_hub_outbound,
     module.peering_hub_inbound,
     module.peering_mesh,
@@ -33,6 +30,7 @@ resource "azapi_resource" "rg_lock" {
     azapi_resource.vhubconnection_routing_intent,
   ]
 }
+
 
 # module.virtual_networks uses the Azure Verified Module to create
 # as many virtual networks as is required by the var.virtual_networks input variable
@@ -60,7 +58,7 @@ module "virtual_networks" {
   tags             = each.value.tags
   enable_telemetry = var.enable_telemetry
 
-  depends_on = [azapi_resource.rg]
+  # depends_on = [azapi_resource.rg]
 }
 
 # module.peering_hub_outbound uses the peering submodule from theAzure Verified Module

--- a/modules/virtualnetwork/main.tf
+++ b/modules/virtualnetwork/main.tf
@@ -22,7 +22,6 @@ resource "azapi_resource" "rg_lock" {
   parent_id = module.virtual_networks[each.key].resource.parent_id
 
   depends_on = [
-
     module.peering_hub_outbound,
     module.peering_hub_inbound,
     module.peering_mesh,
@@ -57,8 +56,6 @@ module "virtual_networks" {
 
   tags             = each.value.tags
   enable_telemetry = var.enable_telemetry
-
-  # depends_on = [azapi_resource.rg]
 }
 
 # module.peering_hub_outbound uses the peering submodule from theAzure Verified Module

--- a/modules/virtualnetwork/outputs.tf
+++ b/modules/virtualnetwork/outputs.tf
@@ -1,9 +1,11 @@
+
 output "resource_group_resource_ids" {
   description = "The created resource group IDs, expressed as a map."
   value = {
-    for k, v in azapi_resource.rg : k => v.id
+    for k, v in module.virtual_networks : k => v.resource.parent_id
   }
 }
+
 
 output "virtual_network_resource_ids" {
   description = "The created virtual network resource IDs, expressed as a map."


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

This pull request fixes the issue where terraform was throwing a 404 error ResourceGroupNotFound when trying to deploy a route table or network security group into the virtual network resource group. By moving the resource_group_data logic out of the virtual network module and moving it to be used against the resource group module allows the network resource group to be created before any network resources if set to enabled.

## This PR fixes/adds/changes/removes

1. fixes #473 

### Breaking changes

1. Existing deployments may try to replace the resources if they are ran again due to the Network resource group being created in a new module.

## Testing evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

This has been tested locally based on several scenarios:

- resource_group_creation_enabled and  resource_group_creation_enabled within the virtual network variable both set to false
- resource_group_creation_enabled set to false and  resource_group_creation_enabled within the virtual network variable set to true
- resource_group_creation_enabled set to true and  resource_group_creation_enabled within the virtual network variable set to false

Below is a screenshot of the resources deployed into the same resource group

<img width="771" height="374" alt="image" src="https://github.com/user-attachments/assets/601fbd2f-6bc7-42b0-95ac-a9b6950061d8" />


## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [x] Created unit and deployment tests and provided evidence.
- [x] Updated relevant and associated documentation.
