### PR TITLE
feat: integrate Azure IPAM with always-on configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,54 @@ This is currently split logically into the following capabilities:
   - Hub & spoke connectivity (peering to a hub network)
   - vWAN connectivity
   - Mesh peering (peering between spokes)
+  - **IPAM (IP Address Management) support** - automatic IP allocation from Azure IPAM pools
 - Role assignments
 - Resource provider (and feature) registration
 - Resource group creation
 - User assigned managed identity creation
   - Federated credential configuration for GitHub Actions, Terraform Cloud, and other providers.
+
+## IPAM Integration
+
+This module uses Azure IPAM (IP Address Management) for automated IP address allocation:
+
+- **Always Enabled**: IPAM is always active for all virtual networks
+- **Intelligent Pool Selection**: Automatically selects the appropriate IPAM pool based on location
+- **Manual Pool Override**: Explicitly specify IPAM pools when needed
+- **Pool Mapping**: Pre-configured pools for different regions
+
+### IPAM Configuration
+
+IPAM is always enabled and requires the Azure Network Manager ID:
+
+```terraform
+# Required IPAM configuration
+azure_network_manager_id = "/subscriptions/.../providers/Microsoft.Network/networkManagers/network-manager-prod"
+
+# VNet configuration with automatic pool selection
+virtual_networks = {
+  "primary" = {
+    name        = "vnet-workload-001"
+    location    = "uksouth"  # Pool auto-selected based on location
+    
+    subnets = {
+      "default" = {
+        name             = "snet-default"
+        address_prefixes = null  # Allocated from IPAM pool
+      }
+    }
+  }
+}
+```
+
+### Pool Selection Logic
+
+The module automatically selects IPAM pools based on:
+- **Location**: `uksouth` or `ukwest` 
+- **Fallback**: Defaults to UK South pool if location not matched
+- **Override**: Specify `ipam_vnet_pool_id` for explicit pool selection
+
+See `terraform.tfvars.example` for detailed configuration examples.
 
 > When creating virtual network peerings, be aware of the [limit of peerings per virtual network](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=%2Fazure%2Fvirtual-network%2Ftoc.json#azure-resource-manager-virtual-networking-limits).
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,31 @@
 locals {
+  # IPAM pool selection mapping based on location only (no role-based labeling)
+  # IPAM is always enabled
+  ipam_pool_selection = {
+    "uksouth" = {
+      default = "${var.azure_network_manager_id}/ipamPools/pool-uksouth-10-152-0"
+      pool_01 = "${var.azure_network_manager_id}/ipamPools/pool-uksouth-10-152-0"
+      pool_02 = "${var.azure_network_manager_id}/ipamPools/pool-uksouth-10-162-0"
+      pool_03 = "${var.azure_network_manager_id}/ipamPools/pool-uksouth-10-163-0"
+      pool_04 = "${var.azure_network_manager_id}/ipamPools/pool-uksouth-10-178-0"
+    }
+    "ukwest" = {
+      default = "${var.azure_network_manager_id}/ipamPools/pool-ukwest-10-152-128"
+      pool_01 = "${var.azure_network_manager_id}/ipamPools/pool-ukwest-10-152-128"
+      pool_02 = "${var.azure_network_manager_id}/ipamPools/pool-ukwest-10-162-128"
+      pool_03 = "${var.azure_network_manager_id}/ipamPools/pool-ukwest-10-163-128"
+      pool_04 = "${var.azure_network_manager_id}/ipamPools/pool-ukwest-10-178-128"
+    }
+  }
+
+  # Default IPAM configuration values - always enabled
+  default_ipam_values = {
+    ipam_network_manager_id              = var.azure_network_manager_id
+    ipam_network_manager_resource_id     = var.azure_network_manager_id
+    ipam_allocate_vnets_from_ipam_pool   = true
+    ipam_allocate_subnets_from_ipam_pool = true
+  }
+
   # subscription_id is the id of the subscription into which resources will be created.
   # We pick the created sub id first, if it exists, otherwise we pick the subscription_id variable.
   subscription_id = coalesce(local.subscription_module_output_subscription_id, var.subscription_id)
@@ -109,6 +136,13 @@ locals {
       vwan_propagated_routetables_labels       = vnet_v.vwan_propagated_routetables_labels
       vwan_propagated_routetables_resource_ids = vnet_v.vwan_propagated_routetables_resource_ids
       vwan_security_configuration              = vnet_v.vwan_security_configuration
+
+      # IPAM-related fields - IPAM is always enabled
+      enable_ipam                 = true
+      ipam_network_manager_id     = coalesce(vnet_v.ipam_network_manager_id, var.azure_network_manager_id)
+      ipam_vnet_pool_id           = coalesce(vnet_v.ipam_vnet_pool_id, try(local.ipam_pool_selection[vnet_v.location]["default"], local.ipam_pool_selection["uksouth"]["default"]))
+      ipam_subnet_allocations     = vnet_v.ipam_subnet_allocations
+      existing_vnet_id            = vnet_v.existing_vnet_id
 
       tags = vnet_v.tags
     }

--- a/modules/virtualnetwork/README.md
+++ b/modules/virtualnetwork/README.md
@@ -8,6 +8,7 @@ Optionally:
 
 - Creates bi-directional peering and/or a virtual WAN connection
 - Creates peerings between the virtual networks (mesh peering)
+- **IPAM Support**: This module now supports IP Address Management (IPAM) functionality with Azure Virtual Network Manager (AVM v0.14.1+). Dynamic address space and subnet allocation is available when IPAM is enabled.
 
 ## Notes
 
@@ -189,6 +190,22 @@ Peerings will only be created between virtual networks with the `mesh_peering_en
   - `secure_internet_traffic`: Whether to forward internet-bound traffic to the destination specified in the routing policy. [optional - default `false`]
   - `secure_private_traffic`: Whether to all internal traffic to the destination specified in the routing policy. Not compatible with `routing_intent_enabled`. [optional - default `false`]
   - `routing_intent_enabled`: Enable to use with a Virtual WAN hub with routing intent enabled. Routing intent on hub is configured outside this module. [optional - default `false`]
+
+### IPAM (IP Address Management) values
+
+The following values configure IPAM functionality for dynamic address space allocation using Azure Virtual Network Manager. **IPAM is now fully supported** with AVM v0.14.1+.
+
+- `enable_ipam`: Whether to enable IPAM allocation for this VNet. When true, address\_space can be allocated dynamically by IPAM. [optional - default `false`]
+- `ipam_network_manager_id`: The full resource ID of the Azure Virtual Network Manager (Network Manager) for IPAM. [optional - required when enable\_ipam is `true`]
+- `ipam_vnet_pool_id`: The full resource ID of the IPAM pool used to allocate the VNet address space. [optional - required when enable\_ipam is `true`]
+- `ipam_subnet_allocations`: Per-subnet IPAM allocations configuration in AVM-compatible format. [optional - use when you want IPAM to manage subnet address spaces]
+- `existing_vnet_id`: The full resource ID of an existing VNet to attach to instead of creating a new one. [optional]
+
+**IPAM Usage Notes**:
+- When `enable_ipam` is `true`, you can omit `address_space` as it will be allocated by IPAM
+- Subnet `address_prefixes` can also be omitted when using `ipam_subnet_allocations`
+- The `azapi` provider is required for IPAM functionality (already configured in this module)
+- Ensure your Azure Virtual Network Manager is properly configured with IPAM pools before use
 
 ### Tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,13 @@ DESCRIPTION
   nullable    = false
 }
 
+# IPAM Configuration Variables
+variable "azure_network_manager_id" {
+  type        = string
+  description = "The resource ID of the Azure Virtual Network Manager used for IPAM. IPAM is always enabled."
+  nullable    = false
+}
+
 variable "disable_telemetry" {
   type        = bool
   default     = false


### PR DESCRIPTION
- Add Azure IPAM support with automatic pool selection based on location
- Remove IPAM toggles - IPAM is now always enabled
- Add azure_network_manager_id as required variable
- Update AVM module to v0.14.1 with IPAM support
- Add intelligent pool selection for uksouth/ukwest regions
- Update documentation and examples for IPAM-first approach
- Remove role-based pool labeling for simplified location-based selection

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. fixes #000

### Breaking changes

1. *Replace me*

## Testing evidence

Please provide testing evidence to show that your Pull Request works/fixes as described and documented above.

## As part of this pull request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [ ] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.
