### PR TITLE
fix: set empty umi role assignments when uma disabled

### DIFF
--- a/main.usermanagedidentity.tf
+++ b/main.usermanagedidentity.tf
@@ -9,6 +9,7 @@ module "usermanagedidentity" {
     can(module.resourcegroup[each.value.resource_group_key].resource_group_resource_id) ? module.resourcegroup[each.value.resource_group_key].resource_group_resource_id : null,
     each.value.resource_group_name_existing != null ? "${local.subscription_resource_id}/resourceGroups/${each.value.resource_group_name_existing}" : null
   )
+
   federated_credentials_advanced        = each.value.federated_credentials_advanced
   federated_credentials_github          = each.value.federated_credentials_github
   federated_credentials_terraform_cloud = each.value.federated_credentials_terraform_cloud


### PR DESCRIPTION
This PR replaces #507 to enable CI/CD checks with required secrets.

Original PR by @mortenlerudjordet

---

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/summary

Adds validation bypass for virtual_network_enabled = false and empty virtual_networks object and umi_enabled = false on user_managed_identities object with role_assignments so plan is allowed to pass without terminating in an error.

## This PR fixes/adds/changes/removes

1. fixes #504 

### Breaking changes

1. No breaking changes

## Testing evidence

Only bypasses validation when virtual_network_enabled = false, so one is allowed to input empty virtual_networks object and also does not fail role assignment logic on umi_enabled = false with user_managed_identities object with role_assignments.

## As part of this pull request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-lz-vending/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-lz-vending/issues), for tracking and closure.
- [x] Run and `make fmt` & `make docs` to format your code and update documentation.
- [ ] Created unit and deployment tests and provided evidence.
- [ ] Updated relevant and associated documentation.